### PR TITLE
Update link.js 

### DIFF
--- a/lib/markdown/link.js
+++ b/lib/markdown/link.js
@@ -15,7 +15,7 @@ module.exports = md => {
       const isSourceLink = /(\/|\.md|\.html)(#[\w-]*)?$/.test(href)
       if (isExternal) {
         addAttr(token, 'target', '_blank')
-        addAttr(token, 'rel', 'noopener')
+        addAttr(token, 'rel', 'noopener noreferrer')
       } else if (isSourceLink) {
         hasOpenRouterLink = true
         tokens[idx] = toRouterLink(token, link)


### PR DESCRIPTION
Updating `rel="noopener noreferrer"` for Edge and (partial) IE11 support:
https://caniuse.com/#search=noopener 
https://caniuse.com/#search=noreferrer
Reason here: https://www.jitbit.com/alexblog/256-targetblank---the-most-underestimated-vulnerability-ever/