### PR TITLE
fix: fix vuepress cant resolve custom theme under .vuepress/theme

### DIFF
--- a/lib/prepare.js
+++ b/lib/prepare.js
@@ -114,7 +114,7 @@ async function resolveOptions (sourceDir) {
     // resolve custom theme
     const themeDir = siteConfig.theme
       ? path.resolve(__dirname, `../../vuepress-theme-${siteConfig.theme}`)
-      : path.resolve(sourceDir, 'theme')
+      : path.resolve(vuepressDir, 'theme')
 
     const themePath = path.resolve(themeDir, 'Layout.vue')
     if (fs.existsSync(themePath)) {


### PR DESCRIPTION
According to the docs, to use a custom layout, I should create a .vuepress/theme directory in your docs root, and then create a Layout.vue file.

But vuepress throws an error, when I follow this instruction.

![](https://i.loli.net/2018/04/14/5ad14873872cf.png)

I found the`themeDir`  should be `path.resolve(vuepressDir, 'theme')`, which would be `/.vuepress/theme`, instead of `path.resolve(sourceDir, 'theme')`, which would be `/theme/`