### PR TITLE
default-theme: use v-html span for feature.details

### DIFF
--- a/lib/default-theme/Home.vue
+++ b/lib/default-theme/Home.vue
@@ -15,7 +15,7 @@
     <div class="features">
       <div class="feature" v-for="feature in data.features">
         <h2>{{ feature.title }}</h2>
-        <p>{{ feature.details }}</p>
+        <p><span v-html="feature.details"></span></p>
       </div>
     </div>
     <Content custom/>


### PR DESCRIPTION
I wanted to include links in the feature details, but they're rendered using standard mustaches so my links were escaped. Switching to a v-html span lets me include links, and I think for this purpose it's fair to trust the input of feature details not to be escaped.

My current workaround is to have my package.json look like this:
```
  "scripts": {
    "vuepress-feature-html-hack": "sed -i -e 's|{{ feature.details }}|<span v-html=\"feature.details\"></span>|g' node_modules/vuepress/lib/default-theme/Home.vue",
    "build-docs": "npm run vuepress-feature-html-hack && vuepress build docs",
```
Very hacky, but feels better than duplicating the entire default theme except this one part.
