### PR TITLE
Don't include files from node_modules

### DIFF
--- a/lib/prepare.js
+++ b/lib/prepare.js
@@ -99,7 +99,7 @@ async function resolveOptions (sourceDir) {
       ? path.resolve(siteConfig.dest)
       : path.resolve(sourceDir, '.vuepress/dist'),
     publicPath: base,
-    pageFiles: sort(await globby(['**/*.md', '!.vuepress'], { cwd: sourceDir })),
+    pageFiles: sort(await globby(['**/*.md', '!.vuepress', '!node_modules'], { cwd: sourceDir })),
     pagesData: null,
     themePath: null,
     notFoundPath: null,


### PR DESCRIPTION
If vuepress is run in the root of a npm package
(eg. `vuepress build .`), it would include all markdown files from
the `node_modules` folder, which breaks the build process.

Maybe this setting should be customizable via `.vuepress/config.js`, so users can exclude other files/folders.