### PR TITLE
fix(style): prevent scrollbar in code

### DIFF
--- a/lib/default-theme/styles/code.styl
+++ b/lib/default-theme/styles/code.styl
@@ -34,7 +34,7 @@
   .highlighted-line
     background-color rgba(0, 0, 0, 66%)
     display block
-    margin 0.1rem -1.8rem 0
+    margin 0.1rem -1.5rem 0
     padding 0.1rem 1.8rem
 
 pre[class="language-js"], pre[class="language-javascript"]


### PR DESCRIPTION
That margin was creating horizontal scroll when it wasn't necessary
![capture](https://user-images.githubusercontent.com/664177/38768914-e08bae02-3ffa-11e8-9cc6-f335ba9b0578.PNG)

this removes the horizontal extra width, removing the scrollbar with it