### PR TITLE
Highlight every second table row

### DIFF
--- a/lib/default-theme/styles/theme.styl
+++ b/lib/default-theme/styles/theme.styl
@@ -132,7 +132,7 @@ table
 
 tr
   border-top 1px solid #dfe2e5
-  &:nth-child(2)
+  &:nth-child(2n)
     background-color #f6f8fa
 
 th, td


### PR DESCRIPTION
The CSS rule `&:nth-child(2)` only highlights the second table row.

This change will highlight every second table row, which improves
readability.