### PR TITLE
Allow index.md files as index pages

### DIFF
--- a/lib/prepare.js
+++ b/lib/prepare.js
@@ -189,7 +189,7 @@ async function genComponentRegistrationFile ({ sourceDir }) {
   return `import Vue from 'vue'\n` + components.map(genImport).join('\n')
 }
 
-const indexRE = /\breadme\.md$/i
+const indexRE = /\b(index|readme)\.md$/i
 const extRE = /\.(vue|md)$/
 
 function fileToPath (file) {


### PR DESCRIPTION
Until now, only `README.md` files got treated as a directory index.

This commit also allows `index.md` to be used as index files.

Related to #17.