### PR TITLE
Missing link in document

### DIFF
--- a/docs/guide/markdown.md
+++ b/docs/guide/markdown.md
@@ -167,7 +167,7 @@ export default {
 
 ## Advanced Configuration
 
-VuePress uses [markdown-it]() as the markdown renderer. A lot of the extensions above are implemented via custom plugins. You can further customize the `markdown-it` instance using the `markdown` option in `.vuepress/config.js`:
+VuePress uses [markdown-it](https://markdown-it.github.io/) as the markdown renderer. A lot of the extensions above are implemented via custom plugins. You can further customize the `markdown-it` instance using the `markdown` option in `.vuepress/config.js`:
 
 ``` js
 module.exports = {

--- a/docs/guide/markdown.md
+++ b/docs/guide/markdown.md
@@ -167,7 +167,7 @@ export default {
 
 ## Advanced Configuration
 
-VuePress uses [markdown-it](https://markdown-it.github.io/) as the markdown renderer. A lot of the extensions above are implemented via custom plugins. You can further customize the `markdown-it` instance using the `markdown` option in `.vuepress/config.js`:
+VuePress uses [markdown-it](https://github.com/markdown-it/markdown-it) as the markdown renderer. A lot of the extensions above are implemented via custom plugins. You can further customize the `markdown-it` instance using the `markdown` option in `.vuepress/config.js`:
 
 ``` js
 module.exports = {


### PR DESCRIPTION
Let me know if you prefer [GitHub URL](https://github.com/markdown-it/markdown-it).

`git grep "]()"` doesn't show anything else, by the way.