### PR TITLE
Commands now defaults targetDir to cwd.

### DIFF
--- a/bin/vuepress.js
+++ b/bin/vuepress.js
@@ -11,19 +11,19 @@ program
   .usage('<command> [options]')
 
 program
-  .command('dev <targetDir>')
+  .command('dev [targetDir]')
   .description('start development server')
   .option('-p, --port <port>', 'use specified port (default: 8080)')
-  .action((dir, { port }) => {
+  .action((dir = '.', { port }) => {
     wrapCommand(dev)(path.resolve(dir), { port })
   })
 
 program
-  .command('build <targetDir>')
+  .command('build [targetDir]')
   .description('build dir as static site')
   .option('-d, --dest <outDir>', 'specify build output dir (default: .vuepress/dist)')
   .option('--debug', 'build in development mode for debugging')
-  .action((dir, { debug, outDir }) => {
+  .action((dir = '.', { debug, outDir }) => {
     wrapCommand(build)(path.resolve(dir), { debug, outDir })
   })
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -23,8 +23,8 @@ npm install -g vuepress
 echo "# Hello VuePress!" > README.md
 
 # start writing
-vuepress dev .
+vuepress dev
 
 # build to static files
-vuepress build .
+vuepress build
 ```

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -12,10 +12,10 @@ npm install -g vuepress
 echo "# Hello VuePress!" > README.md
 
 # start writing
-vuepress dev .
+vuepress dev
 
 # build
-vuepress build .
+vuepress build
 ```
 
 ## Inside an Existing Project


### PR DESCRIPTION
As in #8 targetDir parameter of `dev` and `build` commands are optional and defaults to cwd.
