### PR TITLE
Added escaping of meta tag attribute value

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -6,6 +6,7 @@ module.exports = async function build (sourceDir, cliOptions = {}) {
   const chalk = require('chalk')
   const webpack = require('webpack')
   const { promisify } = require('util')
+  const escape = require('escape-html')
   const rimraf = promisify(require('rimraf'))
   const mkdirp = promisify(require('mkdirp'))
   const readFile = promisify(fs.readFile)
@@ -149,7 +150,7 @@ module.exports = async function build (sourceDir, cliOptions = {}) {
     return meta.map(m => {
       let res = `<meta`
       Object.keys(m).forEach(key => {
-        res += ` ${key}="${m[key]}"`
+        res += ` ${key}="${escape(m[key])}"`
       })
       return res + `>`
     }).join('')

--- a/lib/build.js
+++ b/lib/build.js
@@ -113,7 +113,7 @@ module.exports = async function build (sourceDir, cliOptions = {}) {
   function renderAttrs (attrs = {}) {
     const keys = Object.keys(attrs)
     if (keys.length) {
-      return ' ' + keys.map(name => `${name}="${attrs[name]}"`).join(' ')
+      return ' ' + keys.map(name => `${name}="${escape(attrs[name])}"`).join(' ')
     } else {
       return ''
     }

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "copy-webpack-plugin": "^4.5.1",
     "css-loader": "^0.28.11",
     "es6-promise": "^4.2.4",
+    "escape-html": "^1.0.3",
     "file-loader": "^1.1.11",
     "globby": "^8.0.1",
     "html-webpack-plugin": "^3.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1578,7 +1578,7 @@ es6-promise@^4.2.4:
   version "4.2.4"
   resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-4.2.4.tgz#dc4221c2b16518760bd8c39a52d8f356fc00ed29"
 
-escape-html@~1.0.1:
+escape-html@^1.0.3, escape-html@~1.0.1:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.3.tgz#0258eae4d3d0c0974de1c169188ef0051d1d1988"
 


### PR DESCRIPTION
## Bug: Any occurence of quotation mark causes invaild html being rendered:

example.md
```yaml
meta:
- foo: how to "broke" bar
```
before patch:
```html
<meta foo="how to "broke" bar">
```

after patch:
```html
<meta foo="how to &quot;broke&quot; bar">
````


