### PR TITLE
Update dev instruction to yarn

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ Contributions are welcome!
 ## Development
 
 ``` bash
-npm install
-npm run dev # serves VuePress' own docs with itself
+yarn
+yarn dev # serves VuePress' own docs with itself
 ```
 
 ## License


### PR DESCRIPTION
Since vuepress uses yarn instead of npm, so it's better to recommend contributors to use yarn instead of generating npm's locked file.