### PR TITLE
Clarify the description in Browser API Access Restrictions.

### DIFF
--- a/docs/guide/using-vue.md
+++ b/docs/guide/using-vue.md
@@ -2,7 +2,7 @@
 
 ## Browser API Access Restrictions
 
-Because VuePress applications are server-rendered in Node.js when generating static builds, any Vue usage must conform to the [universal code requirements](https://ssr.vuejs.org/en/universal.html). In short, make sure to only access Browser / DOM APIs in `beforeMounted` or `mounted` hooks.
+Because VuePress applications are server-rendered in Node.js before generating static builds, any Vue usage must conform to the [universal code requirements](https://ssr.vuejs.org/en/universal.html). In short, make sure to only access Browser / DOM APIs in `beforeMounted` or `mounted` hooks.
 
 If you are using or demoing a component that is not SSR friendly (for example containing custom directives), you can wrap them inside the built-in `<ClientOnly>` component:
 


### PR DESCRIPTION
The `Browser API Access Restrictions` is only existing before generating static builds. make this description clearly.