### PR TITLE
[Default Theme] [Sidebar] Overflow-y auto

### DIFF
--- a/lib/default-theme/styles/theme.styl
+++ b/lib/default-theme/styles/theme.styl
@@ -41,7 +41,7 @@ body
   bottom 0
   box-sizing border-box
   border-right 1px solid $borderColor
-  overflow-y scroll
+  overflow-y auto
 
 .content:not(.custom)
   max-width $contentWidth


### PR DESCRIPTION
Auto overflow makes the empty scrollbar disappear when it's not needed but shown when there's not enough vertical space to display all items.