### PR TITLE
Fix home link '/' shouldn’t always stays active

### DIFF
--- a/lib/default-theme/NavLinks.vue
+++ b/lib/default-theme/NavLinks.vue
@@ -4,7 +4,7 @@
     <router-link v-for="item in userLinks"
       :to="item.link"
       :key="item.link"
-      exact>
+      :exact="item.link === '/'">
       {{ item.text }}
     </router-link>
     <!-- github link -->

--- a/lib/default-theme/NavLinks.vue
+++ b/lib/default-theme/NavLinks.vue
@@ -3,7 +3,8 @@
     <!-- user links -->
     <router-link v-for="item in userLinks"
       :to="item.link"
-      :key="item.link">
+      :key="item.link"
+      exact>
       {{ item.text }}
     </router-link>
     <!-- github link -->


### PR DESCRIPTION
so if i add a home route as follows
![screen shot 2018-04-15 at 8 57 09 pm](https://user-images.githubusercontent.com/5266508/38778851-10a26944-40f2-11e8-83db-53eadf3f1e76.png)

the home link remains active even I am at a different page
<img width="553" alt="screen shot 2018-04-15 at 8 57 24 pm" src="https://user-images.githubusercontent.com/5266508/38778914-43840132-40f3-11e8-9eba-54eab865b303.png">
