### PR TITLE
add <kbd> styles

### DIFF
--- a/lib/default-theme/styles/theme.styl
+++ b/lib/default-theme/styles/theme.styl
@@ -71,6 +71,13 @@ p a code
   font-weight 400
   color $accentColor
 
+kbd
+  background #eee
+  border solid 0.15rem #ddd
+  border-bottom solid 0.25rem #ddd
+  border-radius 0.15rem
+  padding 0 0.15em
+
 blockquote
   font-size 1.2rem
   color #999
@@ -120,7 +127,7 @@ a.header-anchor
   &:hover
     text-decoration none
 
-code
+code, kbd
   font-family source-code-pro, Menlo, Monaco, Consolas, "Courier New", monospace
 
 p, ul, ol


### PR DESCRIPTION
This PR adds minimal styling to `<kbd>` elements as a start.

Before:

![image](https://user-images.githubusercontent.com/4206232/38784207-86043e4e-40c3-11e8-8387-3285a26fc907.png)

After:

![image](https://user-images.githubusercontent.com/4206232/38784210-90ec60de-40c3-11e8-98c7-9a2113167248.png)
