### PR TITLE
Allow injecting Vue

### DIFF
--- a/lib/prepare.js
+++ b/lib/prepare.js
@@ -24,9 +24,11 @@ module.exports = async function prepare (sourceDir) {
   // 2. generate routes & user components registration code
   const routesCode = await genRoutesFile(options)
   const componentCode = await genComponentRegistrationFile(options)
+  const injectCode = await genInjectFile(options)
 
   await writeTemp('routes.js', [
     componentCode,
+    injectCode,
     routesCode
   ].join('\n\n'))
 
@@ -247,6 +249,17 @@ async function genRoutesFile ({ siteData: { pages }, sourceDir, pageFiles }) {
   return (
     `import Theme from '@theme'\n` +
     `export const routes = [${pages.map(genRoute).join(',')}\n]`
+  )
+}
+
+async function genInjectFile ({ sourceDir }) {
+  const injectFile = path.resolve(sourceDir, '.vuepress/inject.js')
+  if (!fs.existsSync(injectFile)) {
+    return
+  }
+  return (
+    `import inject from ${JSON.stringify(injectFile)}\n` +
+    `inject(Vue)`
   )
 }
 


### PR DESCRIPTION
This PR is helpful for component developers to show their components, e.g.

`.vuepress/inject.js`:

```js
import FirUI from '../../dist/fir-ui.min.js'
import '../../dist/fir-ui.min.css'

export default Vue => {
  Vue.use(FirUI)
}
```

`components/button.md`:

```md
<f-button type="primary">Button</f-button>
```