### PR TITLE
DOC - Add node version warning.

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ Contributions are welcome!
 
 ## Development
 
+> Please make sure your version of Node.js is greater than 8.
+
 ``` bash
 yarn
 yarn dev # serves VuePress' own docs with itself

--- a/docs/README.md
+++ b/docs/README.md
@@ -28,3 +28,7 @@ vuepress dev
 # build to static files
 vuepress build
 ```
+
+::: warning NODE VERSION
+Please make sure your version of Node.js is greater than 8.
+:::


### PR DESCRIPTION
I have found that many users will encounter some unexpected errors caused by the wrong version of the Node.js, see:

- #21 
- #39 
- #51
- #63 

Although we have set minimum version at `engines` field of `package.json`, but NPM still existed some issues for that, See: https://github.com/npm/npm/issues/12486 

Of course, we can also check the node version at runtime, but it would be better to point out in the document that the **user can avoid these problems in advance**.