### PR TITLE
Always transpile lib directory

### DIFF
--- a/lib/webpack/createBaseConfig.js
+++ b/lib/webpack/createBaseConfig.js
@@ -77,7 +77,7 @@ module.exports = function createBaseConfig ({
           if (filepath.startsWith(libDir)) {
             return false
           }
-          // Don't transpiled node_modules
+          // Don't transpile node_modules
           return /node_modules/.test(filepath)
         }).end()
         .use('buble-loader')

--- a/lib/webpack/createBaseConfig.js
+++ b/lib/webpack/createBaseConfig.js
@@ -68,10 +68,18 @@ module.exports = function createBaseConfig ({
         })
 
   if (!siteConfig.evergreen) {
+    const libDir = path.join(__dirname, '..')
     config.module
       .rule('js')
         .test(/\.js$/)
-        .exclude.add(/node_modules/).end()
+        .exclude.add(filepath => {
+          // Always transpile lib directory
+          if (filepath.startsWith(libDir)) {
+            return false
+          }
+          // Don't transpiled node_modules
+          return /node_modules/.test(filepath)
+        }).end()
         .use('buble-loader')
           .loader('buble-loader')
           .options({


### PR DESCRIPTION
```bash
ERROR in ./node_modules/vuepress/lib/app/app.js
Module parse failed: Unexpected token (76:11)
You may need an appropriate loader to handle this file type.
|   })
|
|   return { ...{ app, router }}
| }
|
 @ ./node_modules/vuepress/lib/app/clientEntry.js 4:0-33 7:24-33
 @ multi ./node_modules/vuepress/lib/app/clientEntry.js
```


Not sure why others didn't get this error, fixed by including `lib` in `js` rule.

Besides, if `siteConfig.evergreen` is enabled it will also throw this error since webpack can't parse object rest spreading for now.

Time to switch to Babel or use es2015-only features?