### PR TITLE
Correctly resolve not-found path

### DIFF
--- a/lib/prepare.js
+++ b/lib/prepare.js
@@ -141,7 +141,7 @@ async function resolveOptions (sourceDir) {
     }
     options.themePath = themePath
 
-    const notFoundPath = path.resolve(themeDir, '/NotFound.vue')
+    const notFoundPath = path.resolve(themeDir, 'NotFound.vue')
     if (fs.existsSync(notFoundPath)) {
       options.notFoundPath = notFoundPath
     } else {


### PR DESCRIPTION
The latest commit broke path resolution for not-found pages in (local) custom themes: https://github.com/vuejs/vuepress/commit/72e5666161675e22c74ebcbcd5034534bdea9f58#diff-a51476be0f7d46d12aa959f6343012ccR67

With this commit, not-found pages are found again. :octocat: 