### PR TITLE
Fix for build destination path

### DIFF
--- a/bin/vuepress.js
+++ b/bin/vuepress.js
@@ -36,7 +36,8 @@ program
   .description('build dir as static site')
   .option('-d, --dest <outDir>', 'specify build output dir (default: .vuepress/dist)')
   .option('--debug', 'build in development mode for debugging')
-  .action((dir = '.', { debug, outDir }) => {
+  .action((dir = '.', { debug, dest }) => {
+    const outDir = dest ? path.resolve(dest) : null
     wrapCommand(build)(path.resolve(dir), { debug, outDir })
   })
 


### PR DESCRIPTION
**Current behavior**
$ vuepress build --dest ./public site/content
Rendering static HTML...
Success! Generated static files in site/content/**.vuepress/dist**.

**Expected behavior**
$ vuepress build --dest ./public site/content
Rendering static HTML...
Success! Generated static files in **public**.
