### PR TITLE
Use header's slug as it is if possible

### DIFF
--- a/lib/util/index.js
+++ b/lib/util/index.js
@@ -59,10 +59,11 @@ exports.extractHeaders = (content, include = [], md) => {
   tokens.forEach((t, i) => {
     if (t.type === 'heading_open' && include.includes(t.tag)) {
       const title = tokens[i + 1].content
+      const slug = t.attrs.find(([name]) => name === 'id')[1]
       res.push({
         level: parseInt(t.tag.slice(1), 10),
         title,
-        slug: md.slugify(title)
+        slug: slug || md.slugify(title)
       })
     }
   })


### PR DESCRIPTION
This fixes an issue concerning missing slug link of sidebar.

## Reproduction

The issue can even be reproduced in the official VuePress guide.

1. Access https://vuepress.vuejs.org/guide/
2. Click the `Why Not ...?` link in sidebar

We can see that the guide page doesn't scroll to the `Why Not ...?` header.

## Reason

The issue is caused by markdown-it's `typographer: true` option, which is for beautification. By the option, three dots (`...`) are replaced with a single unicode character `…`. They are handled differently by [slugify()](https://github.com/vuejs/vuepress/blob/master/lib/markdown/slugify.js).

When logging the tokens, `tokens[i + 1].content` is not `typographer`-ed, even its actual slug is.

## Fix

The token already has an attribute `id` which is a correct and final result of the parser. Also, the slug is used for sidebar links later, so I guess it would be more proper to use `id` as it is.

Please let me know if there is anything unclear.

Thanks!