### PR TITLE
tweak(default-theme): Adds hr element style

### DIFF
--- a/lib/default-theme/styles/theme.styl
+++ b/lib/default-theme/styles/theme.styl
@@ -133,6 +133,10 @@ code, kbd
 p, ul, ol
   line-height 1.7
 
+hr
+  border 0
+  border-top 1px solid $borderColor
+
 table
   border-collapse collapse
   margin 1rem 0


### PR DESCRIPTION
This adds some styling to the hr element which is produced when you have
`---` in markdown on a line on its own. This makes the element look like
all other border elements `1px`, of `$borderColor`.

Before (`<hr>` then border):

![screenshot-2018-4-18 vuepress](https://user-images.githubusercontent.com/171232/38933092-f534ff1c-430f-11e8-905b-3d9abecbaae1.png)

After:
![screenshot-2018-4-18 vuepress 1](https://user-images.githubusercontent.com/171232/38933093-f54ab8f2-430f-11e8-9d0b-e079fa13efac.png)
