### PR TITLE
Enhance the sidebar's bottom gutter.

### DIFF
--- a/lib/default-theme/Sidebar.vue
+++ b/lib/default-theme/Sidebar.vue
@@ -88,12 +88,12 @@ function resolveOpenGroupIndex (route, items) {
       font-size 1.1em
       padding 0.5rem 0 0.5rem 1.5rem
   .sidebar-links
-    margin-top 1.5rem
+    padding 1.5rem 0
 
 @media (max-width: $MQMobile)
   .sidebar
     .nav-links
       display block
     .sidebar-links
-      margin-top 1rem
+      padding 1rem 0
 </style>


### PR DESCRIPTION
### Summary

 - Version: 0.6.0
- Description: The bottom gutter of sidebar in mobile is too small (=0).

### Before

![image](https://user-images.githubusercontent.com/23133919/38934319-0cd9b340-434e-11e8-82db-734b0d2964ed.png)

### After 

![image](https://user-images.githubusercontent.com/23133919/38934341-19de9d1c-434e-11e8-80f7-e2071139bd34.png)
