### PR TITLE
Support click the part outside sidebar to close the sidebar

### DIFF
--- a/lib/default-theme/Layout.vue
+++ b/lib/default-theme/Layout.vue
@@ -4,6 +4,7 @@
     @touchstart="onTouchStart"
     @touchend="onTouchEnd">
     <Navbar v-if="shouldShowNavbar" @toggle-sidebar="toggleSidebar"/>
+    <div class="sidebar-mask" @click="toggleSidebar(false)"></div>
     <Sidebar :items="sidebarItems" @toggle-sidebar="toggleSidebar"/>
     <div class="custom-layout" v-if="$page.frontmatter.layout">
       <component :is="$page.frontmatter.layout"/>

--- a/lib/default-theme/styles/theme.styl
+++ b/lib/default-theme/styles/theme.styl
@@ -29,6 +29,15 @@ body
   box-sizing border-box
   border-bottom 1px solid $borderColor
 
+.sidebar-mask
+  position fixed
+  z-index 9
+  top 0
+  left 0
+  width 100vw
+  height 100vh
+  display none
+
 .sidebar
   font-size 15px
   background-color #fff
@@ -149,11 +158,16 @@ th, td
 .custom-layout
   padding-top $navbarHeight
 
-.theme-container.no-navbar
-  .content:not(.custom)
-    h1, h2, h3, h4, h5, h6
-      margin-top 1.5rem
-      padding-top 0
+.theme-container
+  &.sidebar-open
+    .sidebar-mask
+      display: block
+  &.no-navbar
+    .content:not(.custom)
+      h1, h2, h3, h4, h5, h6
+        margin-top 1.5rem
+        padding-top 0
+
 
 @media (min-width: ($MQMobile + 1px))
   .theme-container.no-sidebar


### PR DESCRIPTION
### Summary

 - Version: 0.6.0
- Description: As a mobile user, I often open the sidebar but didn't make any choices, so it would be good to allow me to check the part outside sidebar to close the sidebar.

### Before

![vuepress-demo-1](https://user-images.githubusercontent.com/23133919/38937488-e5618844-4355-11e8-857d-3c26d5c9b433.gif)

### After 

![vuepress-demo-2](https://user-images.githubusercontent.com/23133919/38937494-e76d7170-4355-11e8-8fa9-f2e51222a403.gif)
