### PR TITLE
Update slugify.js to remove special quotes

### DIFF
--- a/lib/markdown/slugify.js
+++ b/lib/markdown/slugify.js
@@ -3,7 +3,7 @@
 const removeDiacritics = require('diacritics').remove
 // eslint-disable-next-line no-control-regex
 const rControl = /[\u0000-\u001f]/g
-const rSpecial = /[\s~`!@#$%^&*()\-_+=[\]{}|\\;:"'<>,.?/]+/g
+const rSpecial = /[\s~`!@#$%^&*()\-_+=[\]{}|\\;:"'<>,.?“”’/]+/g
 
 module.exports = function slugify (str) {
   return removeDiacritics(str)


### PR DESCRIPTION
I have added `“”’` to the `rSpecial` regex.

This is to fix that the sidebar wouldn't work for titles with quotes. This is due to markdown-it is compiling quotes to those special characters and the our `slugify` function do not remove them.

![](https://imgur.com/a/w02JZ)

From the above photo, my mouse is hovering on the `#` and as you can see it is directing me to `http://localhost:8082/blog/2018-04-18.html#the-%E2%80%9Chello-world%E2%80%9D-website`, yet the sidebar directs me to `http://localhost:8082/blog/2018-04-18.html#the-hello-world-website`.