### PR TITLE
feat: Add docsRepo

### DIFF
--- a/docs/default-theme-config/README.md
+++ b/docs/default-theme-config/README.md
@@ -226,6 +226,8 @@ module.exports = {
   themeConfig: {
     // Assumes GitHub. Can also be a full GitLab url.
     repo: 'vuejs/vuepress',
+    // Your docs repo address
+    docsRepo: 'vuejs/vuepress',
     // if your docs are not at the root of the repo
     docsDir: 'docs',
     // optional, defaults to master

--- a/docs/default-theme-config/README.md
+++ b/docs/default-theme-config/README.md
@@ -226,7 +226,7 @@ module.exports = {
   themeConfig: {
     // Assumes GitHub. Can also be a full GitLab url.
     repo: 'vuejs/vuepress',
-    // Optional, your docs repo address, fallback to repo when it's not given.
+    // Optional, your docs repo address, defaults to `themeConfig.repo`.
     docsRepo: 'vuejs/vuepress',
     // Customising the header label
     // Defaults to "GitHub"/"GitLab"/"Bitbucket" depending on `themeConfig.repo`

--- a/docs/default-theme-config/README.md
+++ b/docs/default-theme-config/README.md
@@ -226,14 +226,17 @@ module.exports = {
   themeConfig: {
     // Assumes GitHub. Can also be a full GitLab url.
     repo: 'vuejs/vuepress',
-    // Optional, your docs repo address, defaults to `themeConfig.repo`.
-    docsRepo: 'vuejs/vuepress',
     // Customising the header label
     // Defaults to "GitHub"/"GitLab"/"Bitbucket" depending on `themeConfig.repo`
     repoLabel: 'Contribute!',
-    // if your docs are not at the root of the repo
+    
+    // Optional options for generating "Edit this page" link
+ 
+    // if your docs are in a different repo from your main project:
+    docsRepo: 'vuejs/vuepress',
+    // if your docs are not at the root of the repo:
     docsDir: 'docs',
-    // optional, defaults to master
+    // if your docs are in a specific branch (defaults to 'master'):
     docsBranch: 'master',
     // defaults to true, set to false to disable
     editLinks: true,

--- a/docs/default-theme-config/README.md
+++ b/docs/default-theme-config/README.md
@@ -226,7 +226,7 @@ module.exports = {
   themeConfig: {
     // Assumes GitHub. Can also be a full GitLab url.
     repo: 'vuejs/vuepress',
-    // Your docs repo address
+    // Optional, your docs repo address, fallback to repo when it's not given.
     docsRepo: 'vuejs/vuepress',
     // if your docs are not at the root of the repo
     docsDir: 'docs',

--- a/docs/zh/default-theme-config/README.md
+++ b/docs/zh/default-theme-config/README.md
@@ -221,7 +221,9 @@ module.exports = {
   themeConfig: {
     // 假定是 GitHub. 同时也可以是一个完整的 GitLab URL
     repo: 'vuejs/vuepress',
-    // 当你的文档不是仓库的根目录时需要设置
+    // 你的文档的地址
+    docsRepo: 'vuejs/vuepress',
+    // 当你的文档不是仓库的根目录时需要设置
     docsDir: 'docs',
     // 可选的, 默认是  master
     docsBranch: 'master',

--- a/docs/zh/default-theme-config/README.md
+++ b/docs/zh/default-theme-config/README.md
@@ -214,7 +214,7 @@ next: false
 ---
 ```
 
-## Github 和编辑链接
+## Git 仓库和编辑链接
 
 当你提供了 `themeConfig.repo` 选项，将会自动在每个页面的导航栏生成生成一个 GitHub 链接，以及在页面的底部生成一个 `"Edit this page"` 链接。
 
@@ -224,12 +224,18 @@ module.exports = {
   themeConfig: {
     // 假定是 GitHub. 同时也可以是一个完整的 GitLab URL
     repo: 'vuejs/vuepress',
-    // 可选的，你的文档库的地址，如果没提供就会使用项目库的地址
+    // 自定义仓库链接文字。默认从 `themeConfig.repo` 中自动推断为
+    // "GitHub"/"GitLab"/"Bitbucket" 其中之一，或是 "Source"。
+    repoLabel: '查看源码',
+    
+    // 以下为可选的编辑链接选项
+
+    // 假如你的文档仓库和项目本身不在一个仓库：
     docsRepo: 'vuejs/vuepress',
-    // 当你的文档不是仓库的根目录时需要设置
-    docsDir: 'docs',
-    // 可选的, 默认是  master
-    docsBranch: 'master',
+    // 假如文档不是放在仓库的根目录下：
+    docsDir: 'docs',
+    // 假如文档放在一个特定的分支下：
+    docsBranch: 'master',
     // 默认是 true, 设置为 false 来禁用
     editLinks: true,
     // 默认为 "Edit this page"

--- a/docs/zh/default-theme-config/README.md
+++ b/docs/zh/default-theme-config/README.md
@@ -221,7 +221,7 @@ module.exports = {
   themeConfig: {
     // 假定是 GitHub. 同时也可以是一个完整的 GitLab URL
     repo: 'vuejs/vuepress',
-    // 你的文档的地址
+    // 可选的，你的文档库的地址，如果没提供就会使用项目库的地址
     docsRepo: 'vuejs/vuepress',
     // 当你的文档不是仓库的根目录时需要设置
     docsDir: 'docs',

--- a/lib/default-theme/Page.vue
+++ b/lib/default-theme/Page.vue
@@ -58,7 +58,7 @@ export default {
         docsBranch = 'master'
       } = this.$site.themeConfig
       
-      let docsRepo = this.$site.themeConfig.docsRepo || repo
+      const docsRepo = this.$site.themeConfig.docsRepo || repo
       let path = normalize(this.$page.path)
       if (endingSlashRE.test(path)) {
         path += 'README.md'

--- a/lib/default-theme/Page.vue
+++ b/lib/default-theme/Page.vue
@@ -53,13 +53,12 @@ export default {
     editLink () {
       const {
         repo,
-        docsRepo,
         editLinks,
         docsDir = '',
         docsBranch = 'master'
       } = this.$site.themeConfig
       
-      docsRepo = docsRepo || repo
+      let docsRepo = this.$site.themeConfig.docsRepo || repo
       let path = normalize(this.$page.path)
       if (endingSlashRE.test(path)) {
         path += 'README.md'

--- a/lib/default-theme/Page.vue
+++ b/lib/default-theme/Page.vue
@@ -52,7 +52,7 @@ export default {
     },
     editLink () {
       const {
-        repo,
+        docRepo,
         editLinks,
         docsDir = '',
         docsBranch = 'master'
@@ -65,10 +65,10 @@ export default {
         path += '.md'
       }
 
-      if (repo && editLinks) {
-        const base = outboundRE.test(repo)
-          ? repo
-          : `https://github.com/${repo}`
+      if (docRepo && editLinks) {
+        const base = outboundRE.test(docRepo)
+          ? docRepo
+          : `https://github.com/${docRepo}`
         return (
           base.replace(endingSlashRE, '') +
           `/edit/${docsBranch}/` +

--- a/lib/default-theme/Page.vue
+++ b/lib/default-theme/Page.vue
@@ -52,7 +52,7 @@ export default {
     },
     editLink () {
       const {
-        docRepo,
+        docsRepo,
         editLinks,
         docsDir = '',
         docsBranch = 'master'
@@ -65,10 +65,10 @@ export default {
         path += '.md'
       }
 
-      if (docRepo && editLinks) {
+      if (docsRepo && editLinks) {
         const base = outboundRE.test(docRepo)
-          ? docRepo
-          : `https://github.com/${docRepo}`
+          ? docsRepo
+          : `https://github.com/${docsRepo}`
         return (
           base.replace(endingSlashRE, '') +
           `/edit/${docsBranch}/` +

--- a/lib/default-theme/Page.vue
+++ b/lib/default-theme/Page.vue
@@ -58,7 +58,7 @@ export default {
         docsBranch = 'master',
         docsRepo = repo
       } = this.$site.themeConfig
-      
+
       let path = normalize(this.$page.path)
       if (endingSlashRE.test(path)) {
         path += 'README.md'

--- a/lib/default-theme/Page.vue
+++ b/lib/default-theme/Page.vue
@@ -66,7 +66,7 @@ export default {
       }
 
       if (docsRepo && editLinks) {
-        const base = outboundRE.test(docRepo)
+        const base = outboundRE.test(docsRepo)
           ? docsRepo
           : `https://github.com/${docsRepo}`
         return (

--- a/lib/default-theme/Page.vue
+++ b/lib/default-theme/Page.vue
@@ -52,12 +52,14 @@ export default {
     },
     editLink () {
       const {
+        repo,
         docsRepo,
         editLinks,
         docsDir = '',
         docsBranch = 'master'
       } = this.$site.themeConfig
-
+      
+      docsRepo = docsRepo || repo
       let path = normalize(this.$page.path)
       if (endingSlashRE.test(path)) {
         path += 'README.md'

--- a/lib/default-theme/Page.vue
+++ b/lib/default-theme/Page.vue
@@ -55,10 +55,10 @@ export default {
         repo,
         editLinks,
         docsDir = '',
-        docsBranch = 'master'
+        docsBranch = 'master',
+        docsRepo = repo
       } = this.$site.themeConfig
       
-      const docsRepo = this.$site.themeConfig.docsRepo || repo
       let path = normalize(this.$page.path)
       if (endingSlashRE.test(path)) {
         path += 'README.md'


### PR DESCRIPTION
In some cases, project and doc are not in the same repo like Vue. So, and a `docsRepo` option  in config file to distinguish project and doc address.