### PR TITLE
feat: support for TOML front matter (#141)

### DIFF
--- a/lib/prepare.js
+++ b/lib/prepare.js
@@ -2,10 +2,9 @@ const path = require('path')
 const fs = require('fs-extra')
 const globby = require('globby')
 const yamlParser = require('js-yaml')
-const yaml = require('yaml-front-matter')
 const createMarkdown = require('./markdown')
 const tempPath = path.resolve(__dirname, 'app/.temp')
-const { inferTitle, extractHeaders } = require('./util')
+const { inferTitle, extractHeaders, parseFrontmatter } = require('./util')
 
 fs.ensureDirSync(tempPath)
 
@@ -160,23 +159,23 @@ async function resolveOptions (sourceDir) {
 
     // extract yaml frontmatter
     const content = await fs.readFile(path.resolve(sourceDir, file), 'utf-8')
-    const frontmatter = yaml.loadFront(content)
+    const frontmatter = parseFrontmatter(content)
     // infer title
     const title = inferTitle(frontmatter)
     if (title) {
       data.title = title
     }
     const headers = extractHeaders(
-      frontmatter.__content,
+      frontmatter.content,
       ['h2', 'h3'],
       options.markdown
     )
     if (headers.length) {
       data.headers = headers
     }
-    delete frontmatter.__content
-    if (Object.keys(frontmatter).length) {
-      data.frontmatter = frontmatter
+    delete frontmatter.content
+    if (Object.keys(frontmatter.data).length) {
+      data.frontmatter = frontmatter.data
     }
     return data
   }))

--- a/lib/util/index.js
+++ b/lib/util/index.js
@@ -26,21 +26,28 @@ exports.applyUserWebpackConfig = function (userConfig, config, isServer) {
 }
 
 exports.inferTitle = function (frontmatter) {
-  if (frontmatter.home) {
+  if (frontmatter.data.home) {
     return 'Home'
   }
-  if (frontmatter.title) {
-    return frontmatter.title
+  if (frontmatter.data.title) {
+    return frontmatter.data.title
   }
-  const match = frontmatter.__content.trim().match(/^#+\s+(.*)/)
+  const match = frontmatter.content.trim().match(/^#+\s+(.*)/)
   if (match) {
     return match[1]
   }
 }
 
 exports.parseFrontmatter = content => {
-  const yaml = require('yaml-front-matter')
-  return yaml.loadFront(content)
+  const matter = require('gray-matter')
+  const toml = require('toml')
+
+  return matter(content, {
+    engines: {
+      toml: toml.parse.bind(toml),
+      excerpt: false
+    }
+  })
 }
 
 const LRU = require('lru-cache')

--- a/lib/webpack/markdownLoader.js
+++ b/lib/webpack/markdownLoader.js
@@ -3,8 +3,7 @@ const path = require('path')
 const hash = require('hash-sum')
 const { EventEmitter } = require('events')
 const { getOptions } = require('loader-utils')
-const yaml = require('yaml-front-matter')
-const { inferTitle, extractHeaders } = require('../util')
+const { inferTitle, extractHeaders, parseFrontmatter } = require('../util')
 const LRU = require('lru-cache')
 
 const cache = LRU({ max: 1000 })
@@ -25,13 +24,13 @@ module.exports = function (src) {
     return cached
   }
 
-  const frontmatter = yaml.loadFront(src)
-  const content = frontmatter.__content
+  const frontmatter = parseFrontmatter(src)
+  const content = frontmatter.content
 
   if (!isProd && !isServer) {
     const inferredTitle = inferTitle(frontmatter)
     const headers = extractHeaders(content, ['h2', 'h3'], markdown)
-    delete frontmatter.__content
+    delete frontmatter.content
 
     // diff frontmatter and title, since they are not going to be part of the
     // returned component, changes in frontmatter do not trigger proper updates

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "file-loader": "^1.1.11",
     "fs-extra": "^5.0.0",
     "globby": "^8.0.1",
+    "gray-matter": "^4.0.1",
     "js-yaml": "^3.11.0",
     "koa-connect": "^2.0.1",
     "koa-mount": "^3.0.0",
@@ -78,6 +79,7 @@
     "semver": "^5.5.0",
     "stylus": "^0.54.5",
     "stylus-loader": "^3.0.2",
+    "toml": "^2.3.3",
     "url-loader": "^1.0.1",
     "vue": "^2.5.16",
     "vue-loader": "^15.0.0-rc.1",
@@ -90,8 +92,7 @@
     "webpack-merge": "^4.1.2",
     "webpack-serve": "^0.3.1",
     "webpackbar": "^2.6.1",
-    "workbox-build": "^3.1.0",
-    "yaml-front-matter": "^4.0.0"
+    "workbox-build": "^3.1.0"
   },
   "devDependencies": {
     "conventional-changelog": "^1.1.23",


### PR DESCRIPTION
I took a stab at swapping out yaml-front-matter for gray-matter to enable TOML front matter. In addition, JSON front matter also works (but I believe it did with yaml-front-matter as well).

Here's an example of how to use TOML front-matter:

```
---toml
title = 'This is a title'
[[meta]]
  name = 'description'
  content = 'hello'
---
```

I also refactored the front matter parsing code a bit, making use of the existing `parseFrontmatter` util.

P.S. This is my first pull request. Please let me know if I am missing anything 😄