### PR TITLE
Improved instructions on github deployment

### DIFF
--- a/docs/guide/deploy.md
+++ b/docs/guide/deploy.md
@@ -4,27 +4,45 @@ The following guides assumes you are placing your docs inside the `docs` directo
 
 ## GitHub Pages
 
-1. Set `base` in `.vuepress/config.js` to your repository's name. For example, if your repository is `https://github.com/foo/bar`, the deployed pages will be available at `https://foo.github.io/bar`. In this case, you should set `base` to `"/bar/"`.
+1. Set `base` in `.vuepress/config.js` to your repository's name. 
 
-2. Inside your project, run:
+   If you are deploying to `https://<USERNAME>.github.io`, set `base` to `"/"`.
 
-``` bash
+   If your are deploying to `https://<USERNAME>.github.io/<REPO>`, (i.e. your repository is at `https://github.com/<USERNAME>/REPO>`), set `base` to `"/<REPO>/"`.
+
+2. Inside your project, create `deploy.sh` with the following content (with highlighted lines uncommented appropriately) and run it to deploy:
+
+::: tip
+You can also run this script in your CI setup to enable automatic deployment on each push.
+:::
+
+``` bash{13,20,23}
+#!/usr/bin/env sh
+
+# abort on errors
+set -e
+
 # build
 vuepress build docs
 
 # navigate into the build output directory
 cd docs/.vuepress/dist
 
+# if you are deploying to a custom domain
+# echo 'www.example.com' > CNAME
+
 git init
 git add -A
 git commit -m 'deploy'
 
-# push to the gh-pages branch of your repo.
-# replace <USERNAME>/<REPO> with your info
-git push -f git@github.com:<USERNAME>/<REPO>.git master:gh-pages
-```
+# if you are deploying to https://<USERNAME>.github.io
+# git push -f git@github.com:<USERNAME>/<USERNAME>.github.io.git master
 
-You can run this script in your CI setup to enable automatic deployment on each push.
+# if you are deploying to https://<USERNAME>.github.io/<REPO>
+# git push -f git@github.com:<USERNAME>/<REPO>.git master:gh-pages
+
+cd -
+```
 
 ## Netlify
 


### PR DESCRIPTION
- added instructions on deploying to `https://<USERNAME>.github.io` as it was not covered previously.
- improved deployment script with `set -e` so that the script exists if `vuepress build docs` fails.
- highlighted lines to be uncommented to make the script work.