### PR TITLE
docs: clarify documentation on how to use links

### DIFF
--- a/docs/guide/markdown.md
+++ b/docs/guide/markdown.md
@@ -26,6 +26,32 @@ If you want to link to another markdown file within a directory, remember to:
 
 1.  Append it with either `.html` or `.md`
 2.  Make sure the case matches since the path is case-sensitive
+#### Example
+
+Given the following directory structure:
+
+```
+.
+├─ README.md
+├─ foo
+│  ├─ README.md
+│  ├─ one.md
+│  └─ two.md
+└─ bar
+   ├─ README.md
+   ├─ three.md
+   └─ four.md
+```
+
+```md
+<!-- Assuming you are writing in your root README.md file -->
+
+[Home](/) <!-- Sends the user to the root README.md -->
+[foo](/foo/) <!-- Sends the user to index.html of directory foo -->
+[foo heading anchor](/foo/#heading) <!-- Anchors user to a heading in the foo README file -->
+[foo - one](/foo/one.html) <!-- You can append .html -->
+[foo - two](/foo/two.md) <!-- Or you can append .md -->
+```
 
 ### External Links
 

--- a/docs/guide/markdown.md
+++ b/docs/guide/markdown.md
@@ -34,6 +34,7 @@ If you want to link to another markdown file within a directory, remember to:
 
 1.  Append it with either `.html` or `.md`
 2.  Make sure the case matches since the path is case-sensitive
+
 #### Example
 
 Given the following directory structure:

--- a/docs/guide/markdown.md
+++ b/docs/guide/markdown.md
@@ -12,10 +12,22 @@ Headers automatically get anchor links applied. Rendering of anchors can be conf
 
 ## Links
 
-- Inbound links ending in `.md` or `.html` are converted to `<router-link>` for SPA navigation.
+### Internal Links
 
-  - [Home](/)
-  - [Configuring Markdown](../config/#markdown)
+Inbound links ending in `.md` or `.html` are converted to `<router-link>` for SPA navigation.
+
+Each sub-directory in your static site should contain a `README.md`. It will automatically be converted to `index.html`.
+
+::: tip
+When writing the relative path to a directory's `index.html`, don't forget to close it off with a `/`, otherwise you will get a 404 (e.g., `/about` vs. `/about/`)
+:::
+
+If you want to link to another markdown file within a directory, remember to:
+
+1.  Append it with either `.html` or `.md`
+2.  Make sure the case matches since the path is case-sensitive
+
+### External Links
 
 - Outbound links automatically gets `target="_blank"`:
 

--- a/docs/guide/markdown.md
+++ b/docs/guide/markdown.md
@@ -44,8 +44,6 @@ Given the following directory structure:
 ```
 
 ```md
-<!-- Assuming you are writing in your root README.md file -->
-
 [Home](/) <!-- Sends the user to the root README.md -->
 [foo](/foo/) <!-- Sends the user to index.html of directory foo -->
 [foo heading anchor](/foo/#heading) <!-- Anchors user to a heading in the foo README file -->

--- a/docs/guide/markdown.md
+++ b/docs/guide/markdown.md
@@ -21,12 +21,12 @@ Each sub-directory in your static site should contain a `README.md`. It will aut
 ::: tip
 When writing the relative path to a directory's `index.html`, don't forget to close it off with a `/`, otherwise you will get a 404.
 
-```
-# You'll get a 404
-/about 
+```md
+<!-- You'll get a 404 -->
+[About Page](/about)
 
-# This is correect
-/about/
+<!-- This is correct -->
+[About Page](/about/)
 ```
 :::
 

--- a/docs/guide/markdown.md
+++ b/docs/guide/markdown.md
@@ -19,7 +19,15 @@ Inbound links ending in `.md` or `.html` are converted to `<router-link>` for SP
 Each sub-directory in your static site should contain a `README.md`. It will automatically be converted to `index.html`.
 
 ::: tip
-When writing the relative path to a directory's `index.html`, don't forget to close it off with a `/`, otherwise you will get a 404 (e.g., `/about` vs. `/about/`)
+When writing the relative path to a directory's `index.html`, don't forget to close it off with a `/`, otherwise you will get a 404.
+
+```
+# You'll get a 404
+/about 
+
+# This is correect
+/about/
+```
 :::
 
 If you want to link to another markdown file within a directory, remember to:


### PR DESCRIPTION
When I was first getting setup with Vuepress, I found it a little confusing on how to link out to the relative markdown files in the directory. It took some exploration and experimentation to figure out what exactly worked, so I wanted to provide an easy to follow explanation to reduce that friction for future users.