### PR TITLE
feat: basic plugin support

### DIFF
--- a/lib/prepare.js
+++ b/lib/prepare.js
@@ -74,7 +74,31 @@ if (!Object.assign) Object.assign = require('object-assign')`
     fs.existsSync(options.themeEnhanceAppPath)
   )
 
+  // 7. handle plugins
+  const pluginFiles = [
+    path.resolve(options.themeDir),
+    path.resolve(sourceDir, '.vuepress')
+  ]
+
+  for (const pluginFile of pluginFiles) {
+    await loadPlugin(pluginFile, options)
+  }
+
   return options
+}
+
+async function loadPlugin (pluginPath, options) {
+  let plugin
+
+  try {
+    plugin = require(pluginPath)
+  } catch (e) {
+    return
+  }
+
+  if (plugin) {
+    await plugin({ options })
+  }
 }
 
 async function resolveOptions (sourceDir) {
@@ -143,6 +167,7 @@ async function resolveOptions (sourceDir) {
 
   if (useDefaultTheme) {
     // use default theme
+    options.themeDir = path.resolve(__dirname, 'default-theme')
     options.themePath = path.resolve(__dirname, 'default-theme/Layout.vue')
     options.notFoundPath = path.resolve(__dirname, 'default-theme/NotFound.vue')
   } else {


### PR DESCRIPTION
Experimental basic plugin support to allow the app and themes to extend the functionality of vuepress. It attempts to load `themeDir/index.js` then `.vuepress/index.js` and gives them access to the options at the end of the prepare method. Plugins can then use this to write extra files such as to write a `_redirects` file to support redirects in netlify:

```
const path = require('path')
const fs = require('fs-extra')

module.exports = async function ({options}) {
  const redirects = options.siteData.pages
    .filter(page => page.frontmatter.aliases)
    .map(page => page.frontmatter.aliases.map(alias => ({
        dest: page.path,
        alias: alias
      })))
    .reduce((acc, aliases) => acc.concat(aliases), [])
    .map(({dest, alias}) => `${alias}\t${dest}`)

  if (redirects.length > 0) {
    await fs.writeFile(
        path.resolve(options.outDir, '_redirects'),
        redirects.join('\n')
    )
  }
}
```

This can also be used for RSS feeds, sitemaps and anything else that needs to be dynamically written based on the posts or config data.

This also allows plugins to modify the options data to inject extra values or config like markdown-it plugins of header metadata.

This currently conflicts with pull request #154 as they both use `themeDir/index.js` for different purposes. I think it is better to use the index.js for plugins and rename the file in #154 but we could also use an alternative file like `plugin.js` (or just drop the pull request as it should be possible to load server side components via the plugin).