### PR TITLE
fix the "github link" on navbar not right showing on mobile device

### DIFF
--- a/lib/default-theme/NavLinks.vue
+++ b/lib/default-theme/NavLinks.vue
@@ -11,7 +11,7 @@
     <!-- repo link -->
     <a v-if="repoLink"
       :href="repoLink"
-      class="repo-link"
+      class="repo-link github-link"
       target="_blank"
       rel="noopener noreferrer">
       {{ repoLabel }}


### PR DESCRIPTION
the github link not get padding class

<img width="644" alt="screen shot 2018-04-22 at 1 43 00 am" src="https://user-images.githubusercontent.com/1291981/39087697-64226cc4-45d7-11e8-81f9-7036d0173f8c.png">

after add github-link cssl class

<img width="645" alt="screen shot 2018-04-22 at 1 43 35 am" src="https://user-images.githubusercontent.com/1291981/39087698-645cc7ac-45d7-11e8-9eef-f2373cbae242.png">
