### PR TITLE
Fixing emoji not showing on sidebars

### DIFF
--- a/docs/guide/markdown.md
+++ b/docs/guide/markdown.md
@@ -67,7 +67,7 @@ meta:
 | col 2 is      | centered      |   $12 |
 | zebra stripes | are neat      |    $1 |
 
-## Emoji
+## Emoji :tada:
 
 **Input**
 

--- a/lib/util/index.js
+++ b/lib/util/index.js
@@ -1,3 +1,8 @@
+const parseEmojis = str => {
+  const emojiData = require('markdown-it-emoji/lib/data/full.json')
+  return str.replace(/:(.+?):/g, (placeholder, key) => emojiData[key] || placeholder)
+}
+
 exports.normalizeHeadTag = tag => {
   if (typeof tag === 'string') {
     tag = [tag]
@@ -30,11 +35,11 @@ exports.inferTitle = function (frontmatter) {
     return 'Home'
   }
   if (frontmatter.title) {
-    return frontmatter.title
+    return parseEmojis(frontmatter.title)
   }
   const match = frontmatter.__content.trim().match(/^#+\s+(.*)/)
   if (match) {
-    return match[1]
+    return parseEmojis(match[1])
   }
 }
 
@@ -58,7 +63,7 @@ exports.extractHeaders = (content, include = [], md) => {
   const res = []
   tokens.forEach((t, i) => {
     if (t.type === 'heading_open' && include.includes(t.tag)) {
-      const title = tokens[i + 1].content
+      const title = parseEmojis(tokens[i + 1].content)
       const slug = t.attrs.find(([name]) => name === 'id')[1]
       res.push({
         level: parseInt(t.tag.slice(1), 10),


### PR DESCRIPTION
Emojis could be written on titles of markdown, but they will not show on the sidebar. So this PR basically contains:

- Fixing for emoji showing as source (e.g. `:tada:`) on sidebar
- Added an emoji to the emoji section to show that this is possible