### PR TITLE
Improved mobile UX for sidebar links

### DIFF
--- a/lib/default-theme/SidebarLink.vue
+++ b/lib/default-theme/SidebarLink.vue
@@ -69,6 +69,8 @@ a.sidebar-link
   border-left 0.25rem solid transparent
   padding 0.35rem 1rem 0.35rem 1.25rem
   line-height 1.4
+  width: 100%
+  box-sizing: border-box
   &:hover
     color $accentColor
   &.active


### PR DESCRIPTION
Sidebar links are not clickable unless accurately on the link text. In my opinion, it would be a better UX if the links are clickable even on the whitespace.

This commit includes:

- Changing the width of the `<a>` tags of the sidebar to 100
- Use border-box so that the browser calculates correctly with the padding