### PR TITLE
Update isActive logic to always checking equality

### DIFF
--- a/lib/default-theme/util.js
+++ b/lib/default-theme/util.js
@@ -46,11 +46,7 @@ export function isActive (route, path) {
   }
   const routePath = normalize(route.path)
   const pagePath = normalize(path)
-  if (endingSlashRE.test(routePath) || endingSlashRE.test(pagePath)) {
-    return routePath === pagePath
-  } else {
-    return routePath.indexOf(pagePath) === 0
-  }
+  return routePath === pagePath
 }
 
 export function resolvePage (pages, rawPath, base) {


### PR DESCRIPTION
Current `isActive` checking will fail when a path is prefixed by another. It causes a problem when showing active indicator in the side bar.

eg:

Say we have two pages under `api` folder, which are `uniwebview.md` and `uniwebviewmessage.md`. When accessing `api/uniwebviewmessage.html`, the result when determining side bar active state for `uniwebview` page is:

routePath: "/api/uniwebviewmessage"
pagePath: "/api/uniwebview"

This leads to both uniwebviewmessage and uniwebview be rendered as actived, which is not correct:

![snip20180423_1](https://user-images.githubusercontent.com/1019875/39110690-16530c2e-470d-11e8-8d1e-26f257f0a795.png)

By changing it to `===`, it goes fine. However, I am not sure whether there would be a regression on this change or not, since there seems like lack of tests for this project.