### PR TITLE
Fix invalid `background-color` value from code block

### DIFF
--- a/lib/default-theme/styles/code.styl
+++ b/lib/default-theme/styles/code.styl
@@ -23,7 +23,7 @@
     code
       color #fff
       padding 0
-      background-color none
+      background-color transparent
       border-radius 0
     &:before
       position absolute


### PR DESCRIPTION
AFAIK, `none` isn't a valid `background-color` value. I changed it to `transparent`. This also resulted the line to match with the rest of the background color on the code block.

This is how it used to look like with `background-color` set to `none`:
![artifact'ish line color](https://i.imgur.com/VIjgW7f.gif)
As you can see, it had slightly different background color.