### PR TITLE
feat: specify the source of the page in the front matter

### DIFF
--- a/docs/default-theme-config/README.md
+++ b/docs/default-theme-config/README.md
@@ -219,6 +219,7 @@ next: false
 ## Git Repo and Edit Links
 
 Providing `themeConfig.repo` auto generates a GitHub link in the navbar and "Edit this page" links at the bottom of each page.
+You can override the generated URL of the edit link for a particular page with a `source` attribute in the front matter.
 
 ``` js
 // .vuepress/config.js

--- a/lib/default-theme/Page.vue
+++ b/lib/default-theme/Page.vue
@@ -58,15 +58,18 @@ export default {
         docsBranch = 'master',
         docsRepo = repo
       } = this.$site.themeConfig
+      const source = this.$page.frontmatter.source
 
-      let path = normalize(this.$page.path)
-      if (endingSlashRE.test(path)) {
-        path += 'README.md'
-      } else {
-        path += '.md'
-      }
+      if (source && editLinks) {
+        return source.replace('/blob/', '/edit/')
+      } else if (docsRepo && editLinks) {
+        let path = normalize(this.$page.path)
+        if (endingSlashRE.test(path)) {
+          path += 'README.md'
+        } else {
+          path += '.md'
+        }
 
-      if (docsRepo && editLinks) {
         const base = outboundRE.test(docsRepo)
           ? docsRepo
           : `https://github.com/${docsRepo}`


### PR DESCRIPTION
This allows to override the default generated GitHub edit link location with a `source` attribute in a page's front matter, for those cases when the original source is not the repository specified in the config.