### PR TITLE
Link nav-item underline to $accentColor

### DIFF
--- a/lib/default-theme/NavLinks.vue
+++ b/lib/default-theme/NavLinks.vue
@@ -129,5 +129,5 @@ export default {
   .nav-item > a
     &:hover, &.router-link-active
       margin-bottom -2px
-      border-bottom 2px solid #42b983
+      border-bottom 2px solid $accentColor
 </style>


### PR DESCRIPTION
It would appear the underline style of `nav-item` should be related to `$accentColor` to avoid color palette clashes if the user supplies `override.styl`.