### PR TITLE
default-theme: Fix editLink computed prop to handle docsRepo

### DIFF
--- a/lib/default-theme/Page.vue
+++ b/lib/default-theme/Page.vue
@@ -53,6 +53,7 @@ export default {
     editLink () {
       const {
         repo,
+        docsRepo,
         editLinks,
         docsDir = '',
         docsBranch = 'master'
@@ -65,7 +66,17 @@ export default {
         path += '.md'
       }
 
-      if (repo && editLinks) {
+      if (docsRepo && repo && editLinks) {
+        const base = outboundRE.test(docsRepo)
+          ? docsRepo
+          : `https://github.com/${docsRepo}`
+        return (
+          base.replace(endingSlashRE, '') +
+          `/edit/${docsBranch}/` +
+          docsDir.replace(endingSlashRE, '') +
+          path
+        )
+      } else if (!docsRepo && repo && editLinks) {
         const base = outboundRE.test(repo)
           ? repo
           : `https://github.com/${repo}`


### PR DESCRIPTION
I guess I fix `editLink()` computed prop pf Page.vue to handle `docsRepo` if it is enabled.
With this PR If the user set up `repo` and `docsRepo`, Vuepress uses `docsRepo` . 
Hope It's help since this is my first PR.