### PR TITLE
Change theme enhance app file name to index.js

### DIFF
--- a/lib/prepare.js
+++ b/lib/prepare.js
@@ -174,7 +174,7 @@ async function resolveOptions (sourceDir) {
       options.notFoundPath = path.resolve(__dirname, 'default-theme/NotFound.vue')
     }
 
-    const themeEnhanceAppPath = path.resolve(themeDir, 'enhanceApp.js')
+    const themeEnhanceAppPath = path.resolve(themeDir, 'index.js')
     if (fs.existsSync(themeEnhanceAppPath)) {
       options.themeEnhanceAppPath = themeEnhanceAppPath
     }


### PR DESCRIPTION
Change `enhanceApp.js` to `index.js` for **Theme Level Enhancements** in order to sync with documentation
> Themes can extend the Vue app that VuePress uses by exposing an `index.js` file at the root of the theme.