### PR TITLE
Lifecycle-based Plugin Support 

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -16,7 +16,7 @@ module.exports = {
     [
       require('./vuepress-plugin-custom-domain'),
       {
-        domain: 'www.v2js.com'
+        domain: 'www.vuejs.org'
       }
     ]
   ],

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -12,6 +12,14 @@ module.exports = {
       description: 'Vue 驱动的静态网站生成器'
     }
   },
+  plugins: [
+    [
+      require('./vuepress-plugin-custom-domain'),
+      {
+        domain: 'www.v2js.com'
+      }
+    ]
+  ],
   head: [
     ['link', { rel: 'icon', href: `/logo.png` }],
     ['link', { rel: 'manifest', href: '/manifest.json' }],

--- a/docs/.vuepress/vuepress-plugin-custom-domain.js
+++ b/docs/.vuepress/vuepress-plugin-custom-domain.js
@@ -1,8 +1,23 @@
 const path = require('path')
-const fs = require('fs')
+const fs = require('fs-extra')
 
-module.exports = async function vuepressPluginCustomDomain({ outDir, pluginOptions: { domain } }) {
-  if (process.env.NODE_ENV === 'production') {
+module.exports = async function vuepressPluginCustomDomain({ domain }) {
+  this
+
+  .ready(() => {
+    console.log('Used vuepress-plugin-custom-domain')
+  })
+
+  .compiled(async ({ outDir }) => {
+    if (process.env.NODE_ENV !== 'production') {
+      return
+    }
+    await fs.ensureDir(outDir)
     await fs.writeFile(path.resolve(outDir, 'CHAME'), domain, 'utf-8')
-  }
+    console.log('Generated CHAME file.')
+  })
+
+  .updated(() => {
+    console.log('Updated')
+  })
 }

--- a/docs/.vuepress/vuepress-plugin-custom-domain.js
+++ b/docs/.vuepress/vuepress-plugin-custom-domain.js
@@ -1,0 +1,8 @@
+const path = require('path')
+const fs = require('fs')
+
+module.exports = async function vuepressPluginCustomDomain({ outDir, pluginOptions: { domain } }) {
+  if (process.env.NODE_ENV === 'production') {
+    await fs.writeFile(path.resolve(outDir, 'CHAME'), domain, 'utf-8')
+  }
+}

--- a/lib/build.js
+++ b/lib/build.js
@@ -13,12 +13,15 @@ module.exports = async function build (sourceDir, cliOptions = {}) {
   const createServerConfig = require('./webpack/createServerConfig')
   const { createBundleRenderer } = require('vue-server-renderer')
   const { normalizeHeadTag, applyUserWebpackConfig } = require('./util')
+  const lifecycle = require('./lifecycle')
 
   process.stdout.write('Extracting site metadata...')
   const options = await prepare(sourceDir)
   if (cliOptions.outDir) {
     options.outDir = cliOptions.outDir
   }
+
+  lifecycle.noticeReady(Object.assign({}, options))
 
   const { outDir } = options
   await fs.remove(outDir)
@@ -35,6 +38,8 @@ module.exports = async function build (sourceDir, cliOptions = {}) {
 
   // compile!
   const stats = await compile([clientConfig, serverConfig])
+
+  await lifecycle.noticeCompiled(Object.assign({}, options))
 
   const serverBundle = require(path.resolve(outDir, 'manifest/server.json'))
   const clientManifest = require(path.resolve(outDir, 'manifest/client.json'))

--- a/lib/build.js
+++ b/lib/build.js
@@ -21,7 +21,7 @@ module.exports = async function build (sourceDir, cliOptions = {}) {
     options.outDir = cliOptions.outDir
   }
 
-  lifecycle.noticeReady(Object.assign({}, options))
+  lifecycle.notifyReady(Object.assign({}, options))
 
   const { outDir } = options
   await fs.remove(outDir)
@@ -39,7 +39,7 @@ module.exports = async function build (sourceDir, cliOptions = {}) {
   // compile!
   const stats = await compile([clientConfig, serverConfig])
 
-  await lifecycle.noticeCompiled(Object.assign({}, options))
+  await lifecycle.notifyCompiled(Object.assign({}, options))
 
   const serverBundle = require(path.resolve(outDir, 'manifest/server.json'))
   const clientManifest = require(path.resolve(outDir, 'manifest/client.json'))

--- a/lib/dev.js
+++ b/lib/dev.js
@@ -21,7 +21,7 @@ module.exports = async function dev (sourceDir, cliOptions = {}) {
   process.stdout.write('Extracting site metadata...\n')
   const options = await prepare(sourceDir)
 
-  lifecycle.noticeReady(Object.assign({}, options))
+  lifecycle.notifyReady(Object.assign({}, options))
 
   if (lifecycle.isEmpty('compiled')) {
     lifecycle.compiled(({ port, displayHost }) => {
@@ -107,9 +107,9 @@ module.exports = async function dev (sourceDir, cliOptions = {}) {
   compiler.hooks.done.tap('vuepress', () => {
     if (isFirst) {
       isFirst = false
-      lifecycle.noticeCompiled(Object.assign({ port, displayHost }, options))
+      lifecycle.notifyCompiled(Object.assign({ port, displayHost }, options))
     } else {
-      lifecycle.noticeUpdated(Object.assign({ port, displayHost }, options))
+      lifecycle.notifyUpdated(Object.assign({ port, displayHost }, options))
     }
   })
 

--- a/lib/dev.js
+++ b/lib/dev.js
@@ -16,9 +16,29 @@ module.exports = async function dev (sourceDir, cliOptions = {}) {
   const createClientConfig = require('./webpack/createClientConfig')
   const { applyUserWebpackConfig } = require('./util')
   const { frontmatterEmitter } = require('./webpack/markdownLoader')
+  const lifecycle = require('./lifecycle')
 
-  process.stdout.write('Extracting site metadata...')
+  process.stdout.write('Extracting site metadata...\n')
   const options = await prepare(sourceDir)
+
+  lifecycle.noticeReady(Object.assign({}, options))
+
+  if (lifecycle.isEmpty('compiled')) {
+    lifecycle.compiled(({ port, displayHost }) => {
+      console.log(
+        `\n  VuePress dev server listening at ${
+          chalk.cyan(`http://${displayHost}:${port}${options.publicPath}`)
+        }\n`
+      )
+    })
+  }
+
+  if (lifecycle.isEmpty('updated')) {
+    lifecycle.updated(() => {
+      const time = new Date().toTimeString().match(/^[\d:]+/)[0]
+      console.log(`  ${chalk.gray(`[${time}]`)} ${chalk.green('✔')} successfully compiled.`)
+    })
+  }
 
   // setup watchers to update options and dynamically generated files
   const update = () => {
@@ -87,14 +107,9 @@ module.exports = async function dev (sourceDir, cliOptions = {}) {
   compiler.hooks.done.tap('vuepress', () => {
     if (isFirst) {
       isFirst = false
-      console.log(
-        `\n  VuePress dev server listening at ${
-          chalk.cyan(`http://${displayHost}:${port}${options.publicPath}`)
-        }\n`
-      )
+      lifecycle.noticeCompiled(Object.assign({ port, displayHost }, options))
     } else {
-      const time = new Date().toTimeString().match(/^[\d:]+/)[0]
-      console.log(`  ${chalk.gray(`[${time}]`)} ${chalk.green('✔')} successfully compiled.`)
+      lifecycle.noticeUpdated(Object.assign({ port, displayHost }, options))
     }
   })
 

--- a/lib/lifecycle.js
+++ b/lib/lifecycle.js
@@ -1,0 +1,34 @@
+const { EventEmitter } = require('events')
+
+const HOOK_NAMES = ['ready', 'compiled', 'updated']
+
+class VuePressHook extends EventEmitter {
+  constructor () {
+    super()
+    HOOK_NAMES.forEach(hook => {
+      const handlerKey = `_${hook}Handlers`
+      const execKey = `notice${hook.charAt(0).toUpperCase() + hook.slice(1)}`
+
+      this[handlerKey] = []
+
+      // public, Add hook handler
+      this[hook] = (handler) => {
+        this[handlerKey].push(handler.bind(this))
+        return this
+      }
+
+      // private, Execute hook handler
+      this[execKey] = async (...args) => {
+        for (const handler of this[handlerKey]) {
+          await handler(...args)
+        }
+      }
+    })
+  }
+
+  isEmpty (hook) {
+    return this[`_${hook}Handlers`].length === 0
+  }
+}
+
+module.exports = new VuePressHook()

--- a/lib/lifecycle.js
+++ b/lib/lifecycle.js
@@ -7,7 +7,7 @@ class VuePressHook extends EventEmitter {
     super()
     HOOK_NAMES.forEach(hook => {
       const handlerKey = `_${hook}Handlers`
-      const execKey = `notice${hook.charAt(0).toUpperCase() + hook.slice(1)}`
+      const execKey = `notify${hook.charAt(0).toUpperCase() + hook.slice(1)}`
 
       this[handlerKey] = []
 

--- a/lib/prepare.js
+++ b/lib/prepare.js
@@ -74,6 +74,15 @@ if (!Object.assign) Object.assign = require('object-assign')`
     fs.existsSync(options.themeEnhanceAppPath)
   )
 
+  // 8. handle plugins
+  for (const [pluginConfig, pluginOptions] of options.plugins) {
+    const pluginFn = resolvePlugin(pluginConfig)
+    const currentPluginExposedFields = Object.assign({}, options, { pluginOptions })
+    if (pluginFn) {
+      await pluginFn(currentPluginExposedFields)
+    }
+  }
+
   return options
 }
 
@@ -111,6 +120,12 @@ async function resolveOptions (sourceDir) {
     })
   }
 
+  // resolve plugins
+  const plugins = (Array.isArray(siteConfig.plugins)
+    ? siteConfig.plugins
+    : []
+  )
+
   // resolve theme
   const useDefaultTheme = (
     !siteConfig.theme &&
@@ -138,6 +153,7 @@ async function resolveOptions (sourceDir) {
     notFoundPath: null,
     useDefaultTheme,
     isAlgoliaSearch,
+    plugins,
     markdown: createMarkdown(siteConfig)
   }
 
@@ -340,4 +356,20 @@ async function parseConfig (file) {
   }
 
   return data || {}
+}
+
+function resolvePlugin (pluginConfig) {
+  if (typeof pluginConfig === 'function') {
+    return pluginConfig
+  }
+  if (typeof pluginConfig === 'string') {
+    try {
+      return require(pluginConfig.startsWith('vuepress-plugin-')
+        ? pluginConfig
+        : `vuepress-plugin-${pluginConfig}`
+      )
+    } catch (err) {
+      throw new Error(`[vuepress] Cannot resolve plugin: ${pluginConfig}`)
+    }
+  }
 }

--- a/lib/prepare.js
+++ b/lib/prepare.js
@@ -5,6 +5,7 @@ const yamlParser = require('js-yaml')
 const tomlParser = require('toml')
 const createMarkdown = require('./markdown')
 const tempPath = path.resolve(__dirname, 'app/.temp')
+const lifecycle = require('./lifecycle')
 const { inferTitle, extractHeaders, parseFrontmatter } = require('./util')
 
 fs.ensureDirSync(tempPath)
@@ -77,9 +78,8 @@ if (!Object.assign) Object.assign = require('object-assign')`
   // 8. handle plugins
   for (const [pluginConfig, pluginOptions] of options.plugins) {
     const pluginFn = resolvePlugin(pluginConfig)
-    const currentPluginExposedFields = Object.assign({}, options, { pluginOptions })
     if (pluginFn) {
-      await pluginFn(currentPluginExposedFields)
+      pluginFn.bind(lifecycle)(pluginOptions)
     }
   }
 
@@ -372,4 +372,5 @@ function resolvePlugin (pluginConfig) {
       throw new Error(`[vuepress] Cannot resolve plugin: ${pluginConfig}`)
     }
   }
+  throw new Error(`[vuepress] Cannot resolve plugin: ${pluginConfig}`)
 }


### PR DESCRIPTION
# Background

We have discussed a lot about the **plugin**:  [the long discussion & vote](https://github.com/vuejs/vuepress/issues/198#issuecomment-383537304), and these awesome PRs:  #196  and #216, 

But when I start to develop plugin at many different situations, I find that the really appropriate plugin mechanism must delay the timing of execution. i.e. we need to support `life cycle` to let plugin developers to be able to do what they want to do at the right moment.

In order to better describe the PR, I drew these two pictures.

<br>

<p align=center><b>vuepress dev &nbsp;&nbsp;&nbsp;<b/></p>
<p align=center><img src='https://user-images.githubusercontent.com/23133919/39200014-81b394b4-481d-11e8-8132-756c9b77e474.png' width='600'/></p>

<br>
<p align=center><b>vuepress build &nbsp;&nbsp;&nbsp;<b/></p>
<p align=center><img src='https://user-images.githubusercontent.com/23133919/39199107-4a8b096a-481b-11e8-8450-84f3b6ada157.png' width='600'/></p>

As shown above, and as we discussed earlier, if we just execute all the plugins at the end of the `prepare`, then once a plugin has written some files to outDir, then you will never see it, which is too bad.

So for now, a plugin would be like this:

```js
module.exports = async function vuepressPluginCustomDomain({ domain } /** only extra plugin options**/) {
  this

   // Execute when prepare is finished, if it's in `build`, the ourDir has been emptied.
   // You do mix extra data and options here before APP launched.
  .ready(() => {
    console.log('Used vuepress-plugin-custom-domain')
  })

  // Execute at the first end of webpack compilation.
  // You can generate extra files here.
  .compiled(async ({ outDir }) => {
    if (process.env.NODE_ENV !== 'production') {
      return
    }
    await fs.ensureDir(outDir)
    await fs.writeFile(path.resolve(outDir, 'CHAME'), domain, 'utf-8')
    console.log('Generated CHAME file.')
  })

   // Execute at each update, only for `dev` 
  .updated(() => {
    console.log('Updated')
  })
}
```

What are the benefits of doing so? for example, if we make the internal log at a default hook handler when we detect there is no other hook handlers, you can override it via plugins, so there would born a separate very handsome plugin.

Of course, It's still worth discussing how to make it better, feel free to give your thoughts.

Thanks~