### PR TITLE
Cursor on search box should be text

### DIFF
--- a/lib/default-theme/SearchBox.vue
+++ b/lib/default-theme/SearchBox.vue
@@ -140,7 +140,7 @@ export default {
   position relative
   margin-right 0.5rem
   input
-    cursor pointer
+    cursor text
     width 10rem
     color lighten($textColor, 25%)
     display inline-block


### PR DESCRIPTION
Currently it does not align with standard web practices, which is to use `cursor: text` on search boxes, and this is confusing. I almost thought the search box was a clickable button.

![cursor](https://user-images.githubusercontent.com/4033249/39214941-0e650544-47cb-11e8-8da5-61eec4c9d966.gif)
