### PR TITLE
add cursor pointer in li

### DIFF
--- a/lib/default-theme/SearchBox.vue
+++ b/lib/default-theme/SearchBox.vue
@@ -171,6 +171,7 @@ export default {
     line-height 1.4
     padding 0.4rem 0.6rem
     border-radius 4px
+    cursor pointer
     a
       color lighten($textColor, 35%)
       .page-title


### PR DESCRIPTION
Only the element `a` has the cursor pointer and it seems that you can only click on it and it can be in all the `li` 

<img src="https://i.imgur.com/4bNpezg.png">