### PR TITLE
tweak: make the SearchBox of default theme better in narrow screen

### DIFF
--- a/lib/default-theme/SearchBox.vue
+++ b/lib/default-theme/SearchBox.vue
@@ -184,14 +184,22 @@ export default {
         color $accentColor
 
 @media (max-width: $MQNarrow)
-  .search-box input
-    width 0
-    border-color transparent
-    position relative
-    left 1rem
-    &:focus
+  .search-box
+    input
+      cursor pointer
+      width 0
+      border-color transparent
+      position relative
+      left 1rem
+      &:focus
+        cursor text
+        left 0
+        width 10rem
+
+@media (max-width: $MQNarrow) and (min-width: $MQMobile)
+  .search-box
+    .suggestions
       left 0
-      width 10rem
 
 @media (max-width: $MQMobile)
   .search-box


### PR DESCRIPTION
- cursor on search box should be pointer when it is not focused in narrow screen (only the icon is displayed)
- when the screen width is between `$MQNarrow` and `$MQMobile`, the `.suggestions` box may overflow the left edge