### PR TITLE
Front End styling tidied up for Search Bar and Nav Links in the Header

### DIFF
--- a/lib/default-theme/NavLinks.vue
+++ b/lib/default-theme/NavLinks.vue
@@ -121,13 +121,6 @@ export default {
   .nav-links
     .nav-item, .repo-link
       margin-left 0.75rem
-
-@media (min-width: $MQNarrow)
-  .nav-links
-    .nav-item, .repo-link
-      margin-left 1.5rem
-
-@media (min-width: $MQMobile)
   .nav-links a
     &:hover, &.router-link-active
       color $textColor
@@ -135,4 +128,9 @@ export default {
     &:hover, &.router-link-active
       margin-bottom -2px
       border-bottom 2px solid lighten($accentColor, 8%)
+
+@media (min-width: $MQNarrow)
+  .nav-links
+    .nav-item, .repo-link
+      margin-left 1.5rem
 </style>

--- a/lib/default-theme/NavLinks.vue
+++ b/lib/default-theme/NavLinks.vue
@@ -117,10 +117,15 @@ export default {
   .repo-link
     margin-left 1.5rem
 
-@media (max-width: $MQMobile)
+@media (min-width: $MQMobile)
   .nav-links
     .nav-item, .repo-link
-      margin-left 0
+      margin-left 0.75rem
+
+@media (min-width: $MQNarrow)
+  .nav-links
+    .nav-item, .repo-link
+      margin-left 1.5rem
 
 @media (min-width: $MQMobile)
   .nav-links a

--- a/lib/default-theme/SearchBox.vue
+++ b/lib/default-theme/SearchBox.vue
@@ -184,17 +184,40 @@ export default {
       a
         color $accentColor
 
-@media (max-width: $MQNarrow)
+@media (max-width: $MQMobile)
   .search-box
+    margin-right 0
+    display inline-block
+    input
+      position relative
+      left 1rem
+      cursor pointer
+      width 0
+      border-color transparent
+      background-color white
+      z-index 10
+      &:focus
+        cursor text
+        width 10rem
+
+@media (min-width: $MQMobile) and (max-width: $MQNarrow)
+  .search-box
+    position relative
+    display inline-block
+    width 30px
+    height 23px
+    margin-right 0
     input
       cursor pointer
       width 0
       border-color transparent
-      position relative
-      left 1rem
+      position absolute
+      background-color white
+      z-index 10
+      left 0
+      top: 0
       &:focus
         cursor text
-        left 0
         width 10rem
 
 @media (max-width: $MQNarrow) and (min-width: $MQMobile)

--- a/lib/default-theme/SearchBox.vue
+++ b/lib/default-theme/SearchBox.vue
@@ -199,6 +199,8 @@ export default {
       &:focus
         cursor text
         width 10rem
+    suggestions:
+      rigt 0
 
 @media (min-width: $MQMobile) and (max-width: $MQNarrow)
   .search-box
@@ -224,12 +226,6 @@ export default {
   .search-box
     .suggestions
       left 0
-
-@media (max-width: $MQMobile)
-  .search-box
-    margin-right 0
-    .suggestions
-      right 0
 
 @media (max-width: $MQMobileNarrow)
   .search-box

--- a/lib/default-theme/SearchBox.vue
+++ b/lib/default-theme/SearchBox.vue
@@ -215,7 +215,7 @@ export default {
       background-color white
       z-index 10
       left 0
-      top: 0
+      top 0
       &:focus
         cursor text
         width 10rem


### PR DESCRIPTION
I noticed the nav in the header had a few small issues at narrow sizes (740px etc) where the Nav Links are overlapping the logo, and focusing the Search Bar breaks out of the layout.

I've reduced the size of the padding on the Nav Links and changed the styling of the focused Search Bar to absolutely position over the top of the Nav at Narrow breakpoints.

Let me know what you think. Cheers