### PR TITLE
Active sidebar link highlight

### DIFF
--- a/lib/app/app.js
+++ b/lib/app/app.js
@@ -58,8 +58,6 @@ export function createApp () {
         return saved
       } else if (to.hash) {
         return false
-        // temp: removed for testing
-        // return { selector: to.hash }
       } else {
         return { x: 0, y: 0 }
       }

--- a/lib/app/app.js
+++ b/lib/app/app.js
@@ -57,7 +57,9 @@ export function createApp () {
       if (saved) {
         return saved
       } else if (to.hash) {
-        return { selector: to.hash }
+        return false
+        // temp: removed for testing
+        // return { selector: to.hash }
       } else {
         return { x: 0, y: 0 }
       }

--- a/lib/default-theme/Layout.vue
+++ b/lib/default-theme/Layout.vue
@@ -162,7 +162,10 @@ export default {
       this.setActiveHash()
     }, 300),
     setActiveHash () {
-      const anchors = document.querySelectorAll('.header-anchor')
+      const sidebarLinks = [].slice.call(document.querySelectorAll('.sidebar-link'))
+      const anchors = [].slice.call(document.querySelectorAll('.header-anchor'))
+        .filter(anchor => sidebarLinks.some(sidebarLink => sidebarLink.hash === anchor.hash))
+        
       const scrollTop = Math.max(window.pageYOffset, document.documentElement.scrollTop, document.body.scrollTop)
 
       for (let i = 0; i < anchors.length; i++) {

--- a/lib/default-theme/Layout.vue
+++ b/lib/default-theme/Layout.vue
@@ -29,7 +29,7 @@ import Page from './Page.vue'
 import Sidebar from './Sidebar.vue'
 import { pathToComponentName } from '@app/util'
 import { resolveSidebarItems } from './util'
-import throttle from 'lodash/throttle'
+import throttle from 'lodash.throttle'
 
 export default {
   components: { Home, Page, Sidebar, Navbar },

--- a/lib/default-theme/Layout.vue
+++ b/lib/default-theme/Layout.vue
@@ -162,8 +162,7 @@ export default {
       this.setActiveHash()
     }, 200),
     setActiveHash () {
-      const anchors = gatherHeaderAnchors()
-
+      const anchors = document.querySelectorAll('.header-anchor')
       const scrollTop = Math.max(window.pageYOffset, document.documentElement.scrollTop, document.body.scrollTop)
 
       for (let i = 0; i < anchors.length; i++) {
@@ -172,7 +171,7 @@ export default {
 
         const isActive = i === 0 && scrollTop === 0 ||
           (scrollTop >= anchor.parentElement.offsetTop + 10 &&
-            (typeof nextAnchor === 'undefined' || scrollTop < nextAnchor.parentElement.offsetTop - 10))
+            (!nextAnchor || scrollTop < nextAnchor.parentElement.offsetTop - 10))
 
         if (isActive && this.$route.hash !== anchor.hash) {
           this.$router.replace(anchor.hash)
@@ -199,15 +198,6 @@ function updateMetaTags (meta, current) {
       return tag
     })
   }
-}
-
-function gatherHeaderAnchors () {
-  const sidebarLinks = Array.from(document.querySelectorAll('.sidebar-group-items a.sidebar-link'))
-
-  const anchors = Array.from(document.querySelectorAll('a.header-anchor'))
-    .filter(x => sidebarLinks.map(x => x.hash).some(hash => hash === x.hash))
-
-  return anchors
 }
 </script>
 

--- a/lib/default-theme/Layout.vue
+++ b/lib/default-theme/Layout.vue
@@ -160,7 +160,7 @@ export default {
     },
     onScroll: throttle(function () {
       this.setActiveHash()
-    }, 200),
+    }, 300),
     setActiveHash () {
       const anchors = document.querySelectorAll('.header-anchor')
       const scrollTop = Math.max(window.pageYOffset, document.documentElement.scrollTop, document.body.scrollTop)

--- a/lib/default-theme/Layout.vue
+++ b/lib/default-theme/Layout.vue
@@ -158,9 +158,28 @@ export default {
         }
       }
     },
-    onScroll: throttle(() => {
-      setActiveHash()
-    }, 200)
+    onScroll: throttle(function () {
+      this.setActiveHash()
+    }, 200),
+    setActiveHash () {
+      const anchors = gatherHeaderAnchors()
+
+      const scrollTop = Math.max(window.pageYOffset, document.documentElement.scrollTop, document.body.scrollTop)
+
+      for (let i = 0; i < anchors.length; i++) {
+        const anchor = anchors[i]
+        const nextAnchor = anchors[i + 1]
+
+        const isActive = i === 0 && scrollTop === 0 ||
+          (scrollTop >= anchor.parentElement.offsetTop + 10 &&
+            (typeof nextAnchor === 'undefined' || scrollTop < nextAnchor.parentElement.offsetTop - 10))
+
+        if (isActive && this.$route.hash !== anchor.hash) {
+          this.$router.replace(anchor.hash)
+          return
+        }
+      }
+    }
   }
 }
 
@@ -182,31 +201,11 @@ function updateMetaTags (meta, current) {
   }
 }
 
-function setActiveHash () {
-  const anchors = gatherHeaderAnchors()
-
-  const scrollTop = Math.max(window.pageYOffset, document.documentElement.scrollTop, document.body.scrollTop)
-
-  for (let i = 0; i < anchors.length; i++) {
-    const anchor = anchors[i]
-    const nextAnchor = anchors[i + 1]
-
-    const isActive = i === 0 && scrollTop === 0 ||
-      (scrollTop >= anchor.parentElement.offsetTop + 10 &&
-        (typeof nextAnchor === 'undefined' || scrollTop < nextAnchor.parentElement.offsetTop - 10))
-
-    if (isActive && window.location.hash !== anchor.hash) {
-      window.location.hash = anchor.hash
-      return
-    }
-  }
-}
-
 function gatherHeaderAnchors () {
   const sidebarLinks = Array.from(document.querySelectorAll('.sidebar-group-items a.sidebar-link'))
 
   const anchors = Array.from(document.querySelectorAll('a.header-anchor'))
-    .filter(x => sidebarLinks.map(x => x.hash).includes(x.hash))
+    .filter(x => sidebarLinks.map(x => x.hash).some(hash => hash === x.hash))
 
   return anchors
 }

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "koa-mount": "^3.0.0",
     "koa-static": "^4.0.2",
     "loader-utils": "^1.1.0",
+    "lodash.throttle": "^4.1.1",
     "lru-cache": "^4.1.2",
     "markdown-it": "^8.4.1",
     "markdown-it-anchor": "^4.0.0",


### PR DESCRIPTION
This is still a work in progress, but I'd really like your feedback on the approach so far.

The main idea here is to gather up all of the anchors, then change the hash when the user scrolls beyond one of the anchor headers. I am filtering the anchors so that we only set the hash to links in the sidebar.

Try it in Chrome/Safari, it should work really nicely! Firefox seems to have different behavior when the hash is changed, though. It jumps to the anchors as soon as they're updated. The result is very jerky scrolling, and scrolling up will immediately skip to the top of a section. Any advice for a better way to do this?