### PR TITLE
fix: postcss-loader warnings about sourceMap (#278)

### DIFF
--- a/lib/webpack/createBaseConfig.js
+++ b/lib/webpack/createBaseConfig.js
@@ -179,7 +179,9 @@ module.exports = function createBaseConfig ({
         if (isProd) {
           rule.use('extract-css-loader').loader(CSSExtractPlugin.loader)
         } else {
-          rule.use('vue-style-loader').loader('vue-style-loader')
+          rule.use('vue-style-loader').loader('vue-style-loader').options({
+            sourceMap: !isProd
+          })
         }
       }
 
@@ -188,12 +190,13 @@ module.exports = function createBaseConfig ({
         .options({
           modules,
           localIdentName: `[local]_[hash:base64:8]`,
-          importLoaders: 1
+          importLoaders: 1,
+          sourceMap: !isProd
         })
 
       rule.use('postcss-loader').loader('postcss-loader').options(Object.assign({
         plugins: [require('autoprefixer')],
-        sourceMap: !isProd
+        sourceMap: !isProd || modules
       }, siteConfig.postcss))
 
       if (loader) {
@@ -203,11 +206,19 @@ module.exports = function createBaseConfig ({
   }
 
   createCSSRule('css', /\.css$/)
-  createCSSRule('scss', /\.scss$/, 'sass-loader', siteConfig.scss)
-  createCSSRule('sass', /\.sass$/, 'sass-loader', Object.assign({ indentedSyntax: true }, siteConfig.sass))
-  createCSSRule('less', /\.less$/, 'less-loader', siteConfig.less)
+  createCSSRule('scss', /\.scss$/, 'sass-loader', Object.assign({
+    sourceMap: !isProd
+  }, siteConfig.scss))
+  createCSSRule('sass', /\.sass$/, 'sass-loader', Object.assign({
+    indentedSyntax: true,
+    sourceMap: !isProd
+  }, siteConfig.sass))
+  createCSSRule('less', /\.less$/, 'less-loader', Object.assign({
+    sourceMap: !isProd
+  }, siteConfig.less))
   createCSSRule('stylus', /\.styl(us)?$/, 'stylus-loader', Object.assign({
-    preferPathResolver: 'webpack'
+    preferPathResolver: 'webpack',
+    sourceMap: !isProd
   }, siteConfig.stylus))
 
   config


### PR DESCRIPTION
Two main changes:
- fix postcss-loader warnings in build mode
- enable sourceMap in development mode

One thing left:
- How to disable `sourceMap` "indeed" when using `css-loader` with `modules: true`