### PR TITLE
fix: docs "default-theme-config" 出现一处言辞重复

### DIFF
--- a/docs/zh/default-theme-config/README.md
+++ b/docs/zh/default-theme-config/README.md
@@ -52,7 +52,7 @@ module.exports = {
 }
 ```
 
-当你提供了一个 `items` 数组而不是一个单一的 `link` 时，它将会显示以 `下拉列表` 的方式显示：
+当你提供了一个 `items` 数组而不是一个单一的 `link` 时，它显示的将是 `下拉列表` ：
 
 ```js
 module.exports = {

--- a/docs/zh/default-theme-config/README.md
+++ b/docs/zh/default-theme-config/README.md
@@ -52,7 +52,7 @@ module.exports = {
 }
 ```
 
-当你提供了一个 `items` 数组而不是一个单一的 `link` 时，它显示的将是 `下拉列表` ：
+当你提供了一个 `items` 数组而不是一个单一的 `link` 时，它将显示为一个 `下拉列表` ：
 
 ```js
 module.exports = {


### PR DESCRIPTION
-当你提供了一个 `items` 数组而不是一个单一的 `link` 时，它将会显示以 `下拉列表` 的方式显示：
+当你提供了一个 `items` 数组而不是一个单一的 `link` 时，它显示的将是 `下拉列表` ：