### PR TITLE
fix(navbar): fix styles when navbar is not present

### DIFF
--- a/lib/default-theme/styles/mobile.styl
+++ b/lib/default-theme/styles/mobile.styl
@@ -21,9 +21,13 @@ $mobileSidebarWidth = $sidebarWidth * 0.82
     transition transform .2s ease
   .page
     padding-left 0
-  .theme-container.sidebar-open
-    .sidebar
-      transform translateX(0)
+  .theme-container
+    &.sidebar-open
+      .sidebar
+        transform translateX(0)
+    &.no-navbar
+      .sidebar
+        padding-top: 0
 
 // narrow mobile
 @media (max-width: $MQMobileNarrow)

--- a/lib/default-theme/styles/theme.styl
+++ b/lib/default-theme/styles/theme.styl
@@ -167,10 +167,14 @@ th, td
     .sidebar-mask
       display: block
   &.no-navbar
-    .content:not(.custom)
+    .content:not(.custom) >
       h1, h2, h3, h4, h5, h6
         margin-top 1.5rem
         padding-top 0
+    .sidebar
+      top 0
+    .custom-layout
+      padding-top 0
 
 
 @media (min-width: ($MQMobile + 1px))


### PR DESCRIPTION
## Before
![dektop guide before](https://user-images.githubusercontent.com/15003767/39480624-1df75966-4d3f-11e8-8a1e-fa475961595d.png)
![mobile guide sidebar before](https://user-images.githubusercontent.com/15003767/39480628-1f12e658-4d3f-11e8-9267-5899bcdbf5c5.png)
## After
![dektop guide after](https://user-images.githubusercontent.com/15003767/39480623-1dcc2d2c-4d3f-11e8-942e-bb4dc1992b1c.png)
![mobile guide sidebar after](https://user-images.githubusercontent.com/15003767/39480627-1eb33726-4d3f-11e8-8f3c-ccd941188243.png)
