### PR TITLE
Change the required node version

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "yorkie": "^1.0.3"
   },
   "engines": {
-    "node": ">=8"
+    "node": ">=8.10"
   },
   "browserslist": [
     ">1%"


### PR DESCRIPTION
I was getting this error:

>$ node bin/vuepress dev docs  
SyntaxError: **Invalid regular expression: /(?<=(^|\/))(index|readme)\.md$/: Invalid group**  
    at Object.<anonymous> (/data/proyectos/blog/vuepress/lib/prepare.js:239:17)

The problem is that [RegExp lookbehind was implemented in V8 in version v6.2.103][look-behind-v8] and it [was just merged into the node engine in version 8.10][look-behind-node].

Check [this forum][forum] for more information.

[look-behind-v8]: https://chromium.googlesource.com/v8/v8.git/+/473a6f5b03651fde33fd7b3228a7dc4e38e24914
[look-behind-node]: https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V8.md#8.10.0
[forum]: https://groups.google.com/forum/#!msg/v8-users/r-SN2yuKTL8/pfwrSuqSBQAJ