### PR TITLE
Change regex to avoid lookbehind

### DIFF
--- a/lib/prepare.js
+++ b/lib/prepare.js
@@ -236,7 +236,7 @@ async function genComponentRegistrationFile ({ sourceDir }) {
   return `import Vue from 'vue'\n` + components.map(genImport).join('\n')
 }
 
-const indexRE = /^\/?([^/]+\/)*(index|readme)\.md$/i
+const indexRE = /(^|.*\/)(index|readme)\.md$/i
 const extRE = /\.(vue|md)$/
 
 function fileToPath (file) {

--- a/lib/prepare.js
+++ b/lib/prepare.js
@@ -243,7 +243,7 @@ function fileToPath (file) {
   if (isIndexFile(file)) {
     // README.md -> /
     // foo/README.md -> /foo/
-    return '/' + file.replace(indexRE, '/$1')
+    return file.replace(indexRE, '/$1')
   } else {
     // foo.md -> /foo.html
     // foo/bar.md -> /foo/bar.html

--- a/lib/prepare.js
+++ b/lib/prepare.js
@@ -236,14 +236,14 @@ async function genComponentRegistrationFile ({ sourceDir }) {
   return `import Vue from 'vue'\n` + components.map(genImport).join('\n')
 }
 
-const indexRE = /(?<=(^|\/))(index|readme)\.md$/i
+const indexRE = /^\/?([^/]+\/)*(index|readme)\.md$/i
 const extRE = /\.(vue|md)$/
 
 function fileToPath (file) {
   if (isIndexFile(file)) {
     // README.md -> /
     // foo/README.md -> /foo/
-    return '/' + file.replace(indexRE, '')
+    return '/' + file.replace(indexRE, '/$1')
   } else {
     // foo.md -> /foo.html
     // foo/bar.md -> /foo/bar.html


### PR DESCRIPTION
An alternative to PR #321.
Also related to PR #308 to fix issue #306.

This is to avoid updating node to 8.10 to support *Regex lookbehind*.