### PR TITLE
feat: Allow page overrides for the sidebar

### DIFF
--- a/lib/default-theme/util.js
+++ b/lib/default-theme/util.js
@@ -119,7 +119,7 @@ export function resolveSidebarItems (page, route, site, localePath) {
     ? themeConfig.locales[localePath] || themeConfig
     : themeConfig
 
-  const sidebarConfig = localeConfig.sidebar || themeConfig.sidebar
+  const sidebarConfig = pageSidebarConfig || localeConfig.sidebar || themeConfig.sidebar
   if (!sidebarConfig) {
     return []
   } else {


### PR DESCRIPTION
This makes it possible to override the sidebar on a per-page level by adding a frontmatter that takes a list of pages in the same format as the site level sidebar. For example:

```
---
sidebar: 
  - /config/
  - /default-theme-config/
---
```