### PR TITLE
feat: register globally theme components (close #281)

### DIFF
--- a/lib/prepare.js
+++ b/lib/prepare.js
@@ -245,16 +245,22 @@ async function resolveOptions (sourceDir) {
   return options
 }
 
-async function genComponentRegistrationFile ({ sourceDir }) {
-  function genImport (file) {
+async function genComponentRegistrationFile ({ sourceDir, themePath }) {
+  function genImport (file, ...componentDir) {
     const name = fileToComponentName(file)
-    const baseDir = path.resolve(sourceDir, '.vuepress/components')
+    const baseDir = path.resolve(...componentDir)
     const absolutePath = path.resolve(baseDir, file)
     const code = `Vue.component(${JSON.stringify(name)}, () => import(${JSON.stringify(absolutePath)}))`
     return code
   }
-  const components = (await resolveComponents(sourceDir)) || []
-  return `import Vue from 'vue'\n` + components.map(genImport).join('\n')
+  const components = (await resolveComponents(sourceDir, '.vuepress/components')) || []
+  const themeComponents = (await resolveComponents(themePath, 'components')) || []
+  const componentsStr =
+      components.map(f => genImport(f, sourceDir, '.vuepress/components')).join('\n')
+  const themeComponentsStr =
+      themeComponents.map(f => genImport(f, themePath, 'components')).join('\n')
+
+  return `import Vue from 'vue'\n${componentsStr}\n${themeComponentsStr}`
 }
 
 const indexRE = /(^|.*\/)(index|readme)\.md$/i
@@ -287,8 +293,8 @@ function isIndexFile (file) {
   return indexRE.test(file)
 }
 
-async function resolveComponents (sourceDir) {
-  const componentDir = path.resolve(sourceDir, '.vuepress/components')
+async function resolveComponents (...sourceDir) {
+  const componentDir = path.resolve(...sourceDir)
   if (!fs.existsSync(componentDir)) {
     return
   }


### PR DESCRIPTION
This pull request allows to register theme components globally, just like the components in `.vuepress/components`.

It makes use of `options.themePath` to include all *.vue in a `components` sub-folder to follow the existing logic.

Closes #281 