### PR TITLE
docs: add surge deploy instructions

### DIFF
--- a/docs/guide/deploy.md
+++ b/docs/guide/deploy.md
@@ -122,3 +122,13 @@ pages:
    ```
 
 3. After running `yarn docs:build` or `npm run docs:build`, deploy with the command `firebase deploy`.
+
+## Surge
+
+1. First install [surge](https://www.npmjs.com/package/surge), if you haven't already.
+
+2. Run `yarn docs:build` or `npm run docs:build`.
+
+3. Deploy to surge, by typing `surge docs/.vuepress/dist`.
+
+You can also deploy to a [custom domain](http://surge.sh/help/adding-a-custom-domain) by adding `surge docs/.vuepress/dist yourdomain.com`.


### PR DESCRIPTION
This pull request adds deploying instructions to [surge](http://surge.sh/) to the documentation.