### PR TITLE
feat: support custom attributes for external links in markdown

### DIFF
--- a/lib/markdown/link.js
+++ b/lib/markdown/link.js
@@ -1,6 +1,7 @@
 // markdown-it plugin for:
 // 1. adding target="_blank" to external links
 // 2. converting internal links to <router-link>
+const querystring = require('querystring')
 
 module.exports = md => {
   let hasOpenRouterLink = false
@@ -10,12 +11,30 @@ module.exports = md => {
     const hrefIndex = token.attrIndex('href')
     if (hrefIndex >= 0) {
       const link = token.attrs[hrefIndex]
-      const href = link[1]
+      // resolve link query params
+      let href = link[1].trim()
+      let query
+      if (href.startsWith('(')) {
+        const queryEndIndex = href.indexOf(')')
+        link[1] = href.slice(queryEndIndex + 1)
+        query = href.slice(1, queryEndIndex)
+        href = link[1]
+      }
+      const queryOb = querystring.parse(query)
       const isExternal = /^https?:/.test(href)
       const isSourceLink = /(\/|\.md|\.html)(#.*)?$/.test(href)
       if (isExternal) {
-        addAttr(token, 'target', '_blank')
-        addAttr(token, 'rel', 'noopener noreferrer')
+        for (const attrKey in queryOb) {
+          if (queryOb[attrKey]) {
+            addAttr(token, attrKey, queryOb[attrKey])
+          }
+        }
+        if (queryOb.target === undefined) {
+          addAttr(token, 'target', '_blank')
+        }
+        if (!queryOb.rel === undefined) {
+          addAttr(token, 'rel', 'noopener noreferrer')
+        }
       } else if (isSourceLink) {
         hasOpenRouterLink = true
         tokens[idx] = toRouterLink(token, link)
@@ -64,3 +83,4 @@ function addAttr (token, name, val) {
     token.attrs[targetIndex][1] = val
   }
 }
+

--- a/lib/markdown/link.js
+++ b/lib/markdown/link.js
@@ -25,14 +25,14 @@ module.exports = md => {
       const isSourceLink = /(\/|\.md|\.html)(#.*)?$/.test(href)
       if (isExternal) {
         for (const attrKey in queryOb) {
-          if (queryOb[attrKey]) {
+          if (queryOb[attrKey].length) {
             addAttr(token, attrKey, queryOb[attrKey])
           }
         }
         if (queryOb.target === undefined) {
           addAttr(token, 'target', '_blank')
         }
-        if (!queryOb.rel === undefined) {
+        if (queryOb.rel === undefined) {
           addAttr(token, 'rel', 'noopener noreferrer')
         }
       } else if (isSourceLink) {


### PR DESCRIPTION
# Summary

- Close: #186

This PR is to support following format to add custom attributes for ONLY **external links**, internal link will keep the old behaviors.

```md
[link-text]((querystring)link)
```

## example 1

- Input: 

```md
[custom domain]((target=_self&class=my-link)http://surge.sh/)
```

- Output: 

```
<a href="http://surge.sh/" target="_self" rel="noopener noreferrer" class="my-link">custom domain</a>
```

## example 2

```md
[custom domain]((target=&rel=)http://surge.sh/)
```

It will be rendered as:

```
<a href="http://surge.sh/">custom domain</a>
```

## example 3

```md
[custom domain](http://surge.sh/)
```

It will be rendered as:

```
<a href="http://surge.sh/" target="_blank" rel="noopener noreferrer">surge</a>
```

So this PR is fully downward compatible.

cc @meteorlxy @ycmjason 