### PR TITLE
Added global config for external links

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -127,6 +127,13 @@ Provide config options to the used theme. The options will vary depending on the
 
 ## Markdown
 
+
+### markdown.link
+- Type: `Object`
+- Default: `{ blank: true }`
+
+Setting `markdown.link.blank` to `false` will cause all external links to open in the same window.
+
 ### markdown.slugify
 
 - Type: `Function`

--- a/docs/guide/markdown.md
+++ b/docs/guide/markdown.md
@@ -48,10 +48,12 @@ Given the following directory structure:
 
 ### External Links
 
-Outbound links automatically gets `target="_blank"`:
+Outbound links automatically gets `target="_blank" rel="noopener noreferrer"`:
 
 - [vuejs.org](https://vuejs.org)
 - [VuePress on GitHub](https://github.com/vuejs/vuepress)
+
+You could alter this this behavior by setting `config.markdown.link.blank = false`. See more [here](/config/#markdown-link).
 
 ## Front Matter
 

--- a/lib/markdown/index.js
+++ b/lib/markdown/index.js
@@ -20,7 +20,9 @@ module.exports = ({ markdown = {}} = {}) => {
     // custom plugins
     .use(component)
     .use(highlightLines)
-    .use(convertRouterLink)
+    .use(convertRouterLink, Object.assign({
+      blank: true
+    }, markdown.link))
     .use(hoistScriptStyle)
     .use(containers)
 

--- a/lib/markdown/link.js
+++ b/lib/markdown/link.js
@@ -1,8 +1,9 @@
 // markdown-it plugin for:
-// 1. adding target="_blank" to external links
+// 1. adding target="_blank" and rel="noopener noreferrer" to external links
+//    (if opts.blank is true)
 // 2. converting internal links to <router-link>
 
-module.exports = md => {
+module.exports = (md, opts) => {
   let hasOpenRouterLink = false
 
   md.renderer.rules.link_open = (tokens, idx, options, env, self) => {
@@ -14,8 +15,10 @@ module.exports = md => {
       const isExternal = /^https?:/.test(href)
       const isSourceLink = /(\/|\.md|\.html)(#.*)?$/.test(href)
       if (isExternal) {
-        addAttr(token, 'target', '_blank')
-        addAttr(token, 'rel', 'noopener noreferrer')
+        if (opts.blank) {
+          addAttr(token, 'target', '_blank')
+          addAttr(token, 'rel', 'noopener noreferrer')
+        }
       } else if (isSourceLink) {
         hasOpenRouterLink = true
         tokens[idx] = toRouterLink(token, link)


### PR DESCRIPTION
Fixing https://github.com/vuejs/vuepress/issues/186

This approach adds a config which switches all external links to use `blank` or no `blank`.

Alt approaches: https://github.com/vuejs/vuepress/pull/356 https://github.com/vuejs/vuepress/pull/358

cc @ulivz @meteorlxy @mathiasbynens