### PR TITLE
fixing dropdown overlapping due to word wrapping

### DIFF
--- a/lib/default-theme/DropdownLink.vue
+++ b/lib/default-theme/DropdownLink.vue
@@ -77,7 +77,6 @@ export default {
           font-size 0.9em
       a
         display block
-        height 1.7rem
         line-height 1.7rem
         position relative
         border-bottom none
@@ -96,7 +95,7 @@ export default {
             border-top 3px solid transparent
             border-bottom 3px solid transparent
             position absolute
-            top calc(50% - 2px)
+            top calc(1rem - 2px)
             left 9px
       &:first-child h4
         margin-top 0
@@ -117,7 +116,6 @@ export default {
           padding-top 0
         h4, & > a
           font-size 15px
-          height 2rem
           line-height 2rem
         .dropdown-subitem
           font-size 14px


### PR DESCRIPTION
Fixing https://github.com/vuejs/vuepress/issues/359

The current style forces the dropdown links to have a fixed height which will cause long lines to overlap to the next line. 

This fix removed the fix height and changed the arrow position to `calc(line height - 2px)`

Briefly tested on desktop and mobile. Please review them. 😄 

cc @ulivz @meteorlxy 