### PR TITLE
Avoid duplicate slash when docsDir is not set

### DIFF
--- a/lib/default-theme/Page.vue
+++ b/lib/default-theme/Page.vue
@@ -77,7 +77,7 @@ export default {
         return (
           base.replace(endingSlashRE, '') +
           `/edit/${docsBranch}` +
-          (docsDir !== '' ? '/' + docsDir.replace(endingSlashRE, '') : '') +
+          (docsDir ? '/' + docsDir.replace(endingSlashRE, '') : '') +
           path
         )
       }

--- a/lib/default-theme/Page.vue
+++ b/lib/default-theme/Page.vue
@@ -76,8 +76,8 @@ export default {
           : `https://github.com/${docsRepo}`
         return (
           base.replace(endingSlashRE, '') +
-          `/edit/${docsBranch}/` +
-          docsDir.replace(endingSlashRE, '') +
+          `/edit/${docsBranch}` +
+          (docsDir !== '' ? '/' + docsDir.replace(endingSlashRE, '') : '') +
           path
         )
       }


### PR DESCRIPTION
When `docsDir` is not set, the url to edit the document currently has two slashes.