### PR TITLE
fix: move ssrContext setting to core (#349, #370)

### DIFF
--- a/lib/app/dataMixin.js
+++ b/lib/app/dataMixin.js
@@ -80,5 +80,12 @@ export default {
         this.$route.path
       )
     }
+  },
+  created () {
+    if (this.$ssrContext) {
+      this.$ssrContext.title = this.$title
+      this.$ssrContext.lang = this.$lang
+      this.$ssrContext.description = this.$page.description || this.$description
+    }
   }
 }

--- a/lib/app/util.js
+++ b/lib/app/util.js
@@ -13,4 +13,8 @@ export function findPageForPath (pages, path) {
       return page
     }
   }
+  return {
+    path: '',
+    frontmatter: {}
+  }
 }

--- a/lib/default-theme/Layout.vue
+++ b/lib/default-theme/Layout.vue
@@ -87,14 +87,6 @@ export default {
     }
   },
 
-  created () {
-    if (this.$ssrContext) {
-      this.$ssrContext.title = this.$title
-      this.$ssrContext.lang = this.$lang
-      this.$ssrContext.description = this.$page.description || this.$description
-    }
-  },
-
   mounted () {
     // update title / meta tags
     this.currentMetaTags = []


### PR DESCRIPTION
- `$ssrContext` is necessary for SSR, so it should be in the core, not in the default theme. #349 
- `NotFound.vue` doesn't match any `$page`, so I provide an empty page data for it in `lib/app/util.js/findPageForPath`, or errors will occur when rendering it. #370 
- As `dataMixin` is not only `data` after this PR, consider renaming it to `globalMixin`? @ulivz 