### PR TITLE
fix(style): sets max-width 100% for images in .content

### DIFF
--- a/lib/default-theme/Home.vue
+++ b/lib/default-theme/Home.vue
@@ -97,6 +97,9 @@ export default {
       color lighten($textColor, 10%)
     p
       color lighten($textColor, 25%)
+  .content
+    img
+      max-width 100%
   .footer
     padding 2.5rem
     border-top 1px solid $borderColor


### PR DESCRIPTION
An overly wide hero image will run out of the container and make the otherwise normally sized page
on mobile horizontally scroll-able.

refs: edm00se/awesome-board-games#5

fixes #381