### PR TITLE
fix(style): sets max-width 100% for images in .content.custom

### DIFF
--- a/lib/default-theme/styles/theme.styl
+++ b/lib/default-theme/styles/theme.styl
@@ -70,6 +70,8 @@ body
 .content.custom
   padding 0
   margin 0
+  img
+    max-width 100%
 
 a
   font-weight 500


### PR DESCRIPTION
An updated PR, from discussion in #382.

an overly wide hero image will run out of the container and make the otherwise normally sized page
on mobile horizontally scroll-able

refs: edm00se/awesome-board-games#5

fixes #381