### PR TITLE
fix: computed parsing errors in notfound

### DIFF
--- a/lib/app/util.js
+++ b/lib/app/util.js
@@ -13,4 +13,8 @@ export function findPageForPath (pages, path) {
       return page
     }
   }
+  return {
+    path: '',
+    frontmatter: {}
+  }
 }


### PR DESCRIPTION
# Before
![before](https://user-images.githubusercontent.com/18205362/39846491-a642bda6-542e-11e8-9e0d-a40adf5523be.png)

# After
![after](https://user-images.githubusercontent.com/18205362/39846503-abaed4be-542e-11e8-8c44-049214715308.png)

# Cause
No `page` matches `NotFound.vue`, so we have to provide an empty page object