### PR TITLE
fix: glob patterns error on windows (#348)

### DIFF
--- a/lib/dev.js
+++ b/lib/dev.js
@@ -26,8 +26,7 @@ module.exports = async function dev (sourceDir, cliOptions = {}) {
       console.error(chalk.red(err.stack))
     })
   }
-  console.log(path.join(sourceDir, '**/*.md'))
-  console.log(path.resolve(sourceDir, '**/*.md'))
+
   // watch add/remove of files
   const pagesWatcher = chokidar.watch([
     '**/*.md',

--- a/lib/dev.js
+++ b/lib/dev.js
@@ -26,12 +26,14 @@ module.exports = async function dev (sourceDir, cliOptions = {}) {
       console.error(chalk.red(err.stack))
     })
   }
-
+  console.log(path.join(sourceDir, '**/*.md'))
+  console.log(path.resolve(sourceDir, '**/*.md'))
   // watch add/remove of files
   const pagesWatcher = chokidar.watch([
-    path.join(sourceDir, '**/*.md'),
-    path.join(sourceDir, '.vuepress/components/**/*.vue')
+    '**/*.md',
+    '.vuepress/components/**/*.vue'
   ], {
+    cwd: sourceDir,
     ignored: '.vuepress/**/*.md',
     ignoreInitial: true
   })


### PR DESCRIPTION
fix #348 

It's not an issue of `chokidar` but ours, as the glob patterns only work with `/` not `\`.
On Windows, `path` module will resolve `/` to `\`.

https://github.com/paulmillr/chokidar/issues/714

I misunderstood what he meant and made some meaningless conversation... I just want to express my thanks to the guy but he locked it immediately 😅 