### PR TITLE
fix: docs broke after previous fix

### DIFF
--- a/docs/guide/using-vue.md
+++ b/docs/guide/using-vue.md
@@ -40,7 +40,7 @@ Each markdown file is first compiled into HTML and then passed on as a Vue compo
 
 **Output**
 
-<pre><code>{{ 1 + 1 }}</code></pre>
+<div class="language-text"><pre><code>{{ 1 + 1 }}</code></pre></div>
 
 ### Directives
 
@@ -54,7 +54,7 @@ Directives also work:
 
 **Output**
 
-<pre><code><span v-for="i in 3">{{ i }} </span></code></pre>
+<div class="language-text"><pre><code><span v-for="i in 3">{{ i }} </span></code></pre></div>
 
 ### Access to Site & Page Data
 

--- a/docs/zh/guide/using-vue.md
+++ b/docs/zh/guide/using-vue.md
@@ -40,7 +40,7 @@ export default {
 
 **Output**
 
-<pre><code>{{ 1 + 1 }}</code></pre>
+<div class="language-text"><pre><code>{{ 1 + 1 }}</code></pre></div>
 
 ### 指令
 
@@ -54,7 +54,7 @@ export default {
 
 **Output**
 
-<pre><code><span v-for="i in 3">{{ i }} </span></code></pre>
+<div class="language-text"><pre><code><span v-for="i in 3">{{ i }} </span></code></pre></div>
 
 ### 访问网站以及页面的数据
 


### PR DESCRIPTION
## Description
---
Docs broke after https://github.com/vuejs/vuepress/commit/d0ef06f5944aada7b5e03fd50eb7f4963fe75d5b

## Before
---
![before](https://user-images.githubusercontent.com/18205362/39953981-c657a2f8-55e8-11e8-8a1f-fce5231dbd51.png)

## After
---
![after](https://user-images.githubusercontent.com/18205362/39953983-cee31ff6-55e8-11e8-898c-327ac3067260.png)
