### PR TITLE
fix: upgrade webpack-serve and avoid port conflict

### DIFF
--- a/lib/dev.js
+++ b/lib/dev.js
@@ -108,7 +108,7 @@ module.exports = async function dev (sourceDir, cliOptions = {}) {
     host,
     dev: { logLevel: 'warn' },
     hot: {
-      port: parseInt(port) + 1,
+      port: port + 1,
       logLevel: 'error'
     },
     logLevel: 'error',

--- a/lib/dev.js
+++ b/lib/dev.js
@@ -107,7 +107,10 @@ module.exports = async function dev (sourceDir, cliOptions = {}) {
     compiler,
     host,
     dev: { logLevel: 'warn' },
-    hot: { logLevel: 'error' },
+    hot: {
+      port: parseInt(port) + 1,
+      logLevel: 'error'
+    },
     logLevel: 'error',
     port,
     add: app => {

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "webpack": "^4.8.1",
     "webpack-chain": "^4.6.0",
     "webpack-merge": "^4.1.2",
-    "webpack-serve": "^0.3.1",
+    "webpack-serve": "0.3.2",
     "webpackbar": "^2.6.1",
     "workbox-build": "^3.1.0"
   },

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "webpack": "^4.8.1",
     "webpack-chain": "^4.6.0",
     "webpack-merge": "^4.1.2",
-    "webpack-serve": "0.3.2",
+    "webpack-serve": "^0.3.2",
     "webpackbar": "^2.6.1",
     "workbox-build": "^3.1.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -7437,9 +7437,9 @@ webpack-merge@^4.1.2:
   dependencies:
     lodash "^4.17.5"
 
-webpack-serve@^0.3.1:
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/webpack-serve/-/webpack-serve-0.3.1.tgz#a91a99d013a70d2c15df2d12c5d31a8842c033ba"
+webpack-serve@0.3.2:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/webpack-serve/-/webpack-serve-0.3.2.tgz#9cfd823dd570438d8cf362e70586bc54af1f0c92"
   dependencies:
     "@shellscape/koa-static" "^4.0.4"
     chalk "^2.3.0"


### PR DESCRIPTION
close #424

related https://github.com/webpack-contrib/webpack-serve/issues/135

## Before
---
![before](https://user-images.githubusercontent.com/18205362/39954983-820a1938-55fb-11e8-91f3-192b70d435e8.png)

## After
---
![after](https://user-images.githubusercontent.com/18205362/39954984-88490bec-55fb-11e8-8499-ef8325aa5d76.png)

