### PR TITLE
chore: allow class and style merging for content

### DIFF
--- a/lib/app/Content.js
+++ b/lib/app/Content.js
@@ -10,9 +10,10 @@ export default {
     }
   },
 
-  render (h, { parent, props }) {
+  render (h, { parent, props, data }) {
     return h(pathToComponentName(parent.$page.path), {
-      class: props.custom ? 'custom' : ''
+      class: [props.custom ? 'custom' : '', data.class, data.staticClass],
+      style: data.style
     })
   }
 }


### PR DESCRIPTION
> Details explained by Evan: https://github.com/vuejs/vue-loader/issues/1014#issuecomment-338281037

close #429

When using `<Content>` like this:
```
<Content class="post-content markdown-body"/>
```

## Before
---
![before](https://user-images.githubusercontent.com/18205362/39956532-39340f24-5615-11e8-92db-e477ed8b9327.png)


## After
---
![after](https://user-images.githubusercontent.com/18205362/39956536-3f437472-5615-11e8-9873-532a0906d812.png)
