### PR TITLE
chore: language-ts alias and highlight support

### DIFF
--- a/lib/default-theme/styles/code.styl
+++ b/lib/default-theme/styles/code.styl
@@ -42,6 +42,10 @@ div[class="language-js"], div[class="language-javascript"]
   &:before
     content "js"
 
+div[class="language-ts"], div[class="language-typescript"]
+  &:before
+    content "ts"
+
 div[class="language-html"], div[class="language-markup"]
   &:before
     content "html"

--- a/lib/markdown/highlight.js
+++ b/lib/markdown/highlight.js
@@ -25,6 +25,9 @@ module.exports = (str, lang) => {
   if (lang === 'md') {
     lang = 'markdown'
   }
+  if (lang === 'ts') {
+    lang = 'typescript'
+  }
   if (!prism.languages[lang]) {
     try {
       loadLanguages([lang])


### PR DESCRIPTION
````
```ts
const test = "test code"
```
````
## Before
---
![image](https://user-images.githubusercontent.com/18205362/39957282-18aef756-5623-11e8-895e-c4a71db727a0.png)
![image](https://user-images.githubusercontent.com/18205362/39957298-5456e2f0-5623-11e8-8fc1-afff5d9cd9d8.png)

## After
---
![image](https://user-images.githubusercontent.com/18205362/39957306-724294bc-5623-11e8-8f19-d2335ee68d1a.png)

