### PR TITLE
Fix typo in home styling

### DIFF
--- a/lib/default-theme/Home.vue
+++ b/lib/default-theme/Home.vue
@@ -83,7 +83,7 @@ export default {
     display flex
     flex-wrap wrap
     align-items flex-start
-    align-content strech
+    align-content stretch
     justify-content space-between
   .feature
     flex-grow 1


### PR DESCRIPTION
I noticed in the browser devtools that the default theme tried to use `align-content: strech`. This must've been a typo 🙂 

