### PR TITLE
fix: highlight lines are cut when sliding

### DIFF
--- a/lib/default-theme/styles/code.styl
+++ b/lib/default-theme/styles/code.styl
@@ -27,14 +27,13 @@ div[class*="language-"]
   background-color $codeBgColor
   border-radius 6px
   .highlight-lines
+    user-select none
     padding-top 1.3rem
     position absolute
     z-index 0
     width 100%
     line-height 1.4
     .highlighted
-      display block
-      width 100%
       background-color rgba(0, 0, 0, 66%)
   pre
     position relative

--- a/lib/default-theme/styles/code.styl
+++ b/lib/default-theme/styles/code.styl
@@ -27,7 +27,7 @@ div[class*="language-"]
   background-color $codeBgColor
   border-radius 6px
   .highlight-lines-wrapper
-    padding 1.25rem 0
+    padding-top 1.3rem
     position absolute
     z-index 0
     width 100%

--- a/lib/default-theme/styles/code.styl
+++ b/lib/default-theme/styles/code.styl
@@ -26,7 +26,7 @@ div[class*="language-"]
   position relative
   background-color $codeBgColor
   border-radius 6px
-  .highlight-lines-wrapper
+  .highlight-lines
     padding-top 1.3rem
     position absolute
     z-index 0

--- a/lib/default-theme/styles/code.styl
+++ b/lib/default-theme/styles/code.styl
@@ -21,18 +21,27 @@
       padding 0
       background-color transparent
       border-radius 0
-  .highlighted-line
-    background-color rgba(0, 0, 0, 66%)
-    display block
-    margin 0 -1.5rem
-    padding 0 1.5rem
 
 div[class*="language-"]
   position relative
   background-color $codeBgColor
   border-radius 6px
+  .highlight-lines-wrapper
+    padding 1.25rem 0
+    position absolute
+    z-index 0
+    width 100%
+    line-height 1.4
+    .highlighted
+      display block
+      width 100%
+      background-color rgba(0, 0, 0, 66%)
+  pre
+    position relative
+    z-index 1
   &::before
     position absolute
+    z-index 3
     top 0.8em
     right 1em
     font-size 0.75rem

--- a/lib/markdown/highlightLines.js
+++ b/lib/markdown/highlightLines.js
@@ -1,4 +1,4 @@
-// forked from https://github.com/egoist/markdown-it-highlight-lines
+// Modified from https://github.com/egoist/markdown-it-highlight-lines
 
 const RE = /{([\d,-]+)}/
 const wrapperRE = /^<pre .*?><code>/
@@ -42,7 +42,7 @@ module.exports = md => {
     }).join('')
 
     const highlightLinesWrapperCode =
-      `<div class="highlight-lines-wrapper">${highlightLinesCode}</div>`
+      `<div class="highlight-lines">${highlightLinesCode}</div>`
 
     return highlightLinesWrapperCode + code
   }

--- a/lib/markdown/highlightLines.js
+++ b/lib/markdown/highlightLines.js
@@ -36,7 +36,7 @@ module.exports = md => {
         return lineNumber === start
       })
       if (inRange) {
-        return `<span class="highlighted">&nbsp;</span>`
+        return `<div class="highlighted">&nbsp;</div>`
       }
       return '<br>'
     }).join('')

--- a/lib/markdown/highlightLines.js
+++ b/lib/markdown/highlightLines.js
@@ -27,9 +27,7 @@ module.exports = md => {
       : token.content
 
     const rawCode = code.replace(wrapperRE, '')
-    const leadingWrapper = code.match(wrapperRE)[0]
-
-    const codeSplits = rawCode.split('\n').map((split, index) => {
+    const highlightLinesCode = rawCode.split('\n').map((split, index) => {
       const lineNumber = index + 1
       const inRange = lineNumbers.some(([start, end]) => {
         if (start && end) {
@@ -38,23 +36,14 @@ module.exports = md => {
         return lineNumber === start
       })
       if (inRange) {
-        return {
-          code: `<span class="highlighted-line">${split || '\n'}</span>`,
-          highlighted: true
-        }
+        return `<span class="highlighted">&nbsp;</span>`
       }
-      return {
-        code: split
-      }
-    })
-    let highlightedCode = leadingWrapper
-    codeSplits.forEach(split => {
-      if (split.highlighted) {
-        highlightedCode += split.code
-      } else {
-        highlightedCode += `${split.code}\n`
-      }
-    })
-    return highlightedCode
+      return '<br>'
+    }).join('')
+
+    const highlightLinesWrapperCode =
+      `<div class="highlight-lines-wrapper">${highlightLinesCode}</div>`
+
+    return highlightLinesWrapperCode + code
   }
 }

--- a/lib/markdown/preWrapper.js
+++ b/lib/markdown/preWrapper.js
@@ -1,4 +1,11 @@
 // markdown-it plugin for wrapping <pre> ... </pre>.
+//
+// If your plugin was chained before preWrapper, you can add additional eleemnt directly.
+// If your plugin was chained after preWrapper, you can use these slots:
+//   1. <!--beforebegin-->
+//   2. <!--afterbegin-->
+//   3. <!--beforeend-->
+//   4. <!--afterend-->
 
 module.exports = md => {
   const fence = md.renderer.rules.fence
@@ -6,6 +13,7 @@ module.exports = md => {
     const [tokens, idx] = args
     const token = tokens[idx]
     const rawCode = fence(...args)
-    return `<!--beforebegin--><div class="language-${token.info.trim()}"><!--afterbegin-->${rawCode}<!--beforeend--></div><!--afterend-->`
+    return `<!--beforebegin--><div class="language-${token.info.trim()}">` +
+    `<!--afterbegin-->${rawCode}<!--beforeend--></div><!--afterend-->`
   }
 }


### PR DESCRIPTION


## Background

This issue was introduced by fixing #350 at d0ef06f5944aada7b5e03fd50eb7f4963fe75d5b, and due to `<span> in <code> cannot expand to 100% width of <code>`.

Since we have hoisted `pre-wrapper` as a standalone plugin at 45a3df5162834abf2c205ccaa4135f23e44e3ece, we can also hoist the highlight lines element as an adjacent element to `<pre>` and create new stacking context to implement the same function.

BTW, the advantage of this PR is that we can avoid modifying the code in `<pre><code>` directly.

## Before (Actual Behaviors)

![highlight-issue](https://user-images.githubusercontent.com/23133919/39964729-e43d6430-56bd-11e8-9142-4fde00034bbf.gif)

## After (Expected Behaviors)

![highlight-issue-after](https://user-images.githubusercontent.com/23133919/39964790-0966f072-56bf-11e8-9afb-6c025866bcdc.gif)




