### PR TITLE
feat: e.skipWaiting() in sw-update event

### DIFF
--- a/lib/app/SWUpdateEvent.js
+++ b/lib/app/SWUpdateEvent.js
@@ -8,6 +8,13 @@ export default class SWUpdateEvent {
   }
 
   /**
+   * Check if the new service worker exists or not.
+   */
+  update () {
+    return this.registration.update()
+  }
+
+  /**
    * Activate new service worker to work 'location.reload()' with new data.
    */
   skipWaiting () {

--- a/lib/app/SWUpdateEvent.js
+++ b/lib/app/SWUpdateEvent.js
@@ -1,0 +1,35 @@
+export default class SWUpdateEvent {
+  constructor (registration) {
+    Object.defineProperty(this, 'registration', {
+      value: registration,
+      configurable: true,
+      writable: true
+    })
+  }
+
+  /**
+   * Activate new service worker to work 'location.reload()' with new data.
+   */
+  skipWaiting () {
+    const worker = this.registration.waiting
+    if (!worker) {
+      return Promise.resolve()
+    }
+
+    console.log('[vuepress:sw] Doing worker.skipWaiting().')
+    return new Promise((resolve, reject) => {
+      const channel = new MessageChannel()
+
+      channel.port1.onmessage = (event) => {
+        console.log('[vuepress:sw] Done worker.skipWaiting().')
+        if (event.data.error) {
+          reject(event.data.error)
+        } else {
+          resolve(event.data)
+        }
+      }
+
+      worker.postMessage({ type: 'skip-waiting' }, [channel.port2])
+    })
+  }
+}

--- a/lib/app/clientEntry.js
+++ b/lib/app/clientEntry.js
@@ -1,6 +1,7 @@
 /* global BASE_URL, GA_ID, ga, SW_ENABLED */
 
 import { createApp } from './app'
+import SWUpdateEvent from './SWUpdateEvent'
 import { register } from 'register-service-worker'
 
 const { app, router } = createApp()
@@ -47,7 +48,10 @@ router.onReady(() => {
       },
       updated () {
         console.log('[vuepress:sw] Content updated.')
-        app.$refs.layout.$emit('sw-updated')
+
+        navigator.serviceWorker.getRegistration().then(registration => {
+          app.$refs.layout.$emit('sw-updated', new SWUpdateEvent(registration))
+        })
       },
       offline () {
         console.log('[vuepress:sw] No internet connection found. App is running in offline mode.')

--- a/lib/app/clientEntry.js
+++ b/lib/app/clientEntry.js
@@ -42,16 +42,13 @@ router.onReady(() => {
         console.log('[vuepress:sw] Service worker is active.')
         app.$refs.layout.$emit('sw-ready')
       },
-      cached () {
+      cached (registration) {
         console.log('[vuepress:sw] Content has been cached for offline use.')
-        app.$refs.layout.$emit('sw-cached')
+        app.$refs.layout.$emit('sw-cached', new SWUpdateEvent(registration))
       },
-      updated () {
+      updated (registration) {
         console.log('[vuepress:sw] Content updated.')
-
-        navigator.serviceWorker.getRegistration().then(registration => {
-          app.$refs.layout.$emit('sw-updated', new SWUpdateEvent(registration))
-        })
+        app.$refs.layout.$emit('sw-updated', new SWUpdateEvent(registration))
       },
       offline () {
         console.log('[vuepress:sw] No internet connection found. App is running in offline mode.')

--- a/lib/build.js
+++ b/lib/build.js
@@ -81,11 +81,16 @@ module.exports = async function build (sourceDir, cliOptions = {}) {
   if (options.siteConfig.serviceWorker) {
     logger.wait('\nGenerating service worker...')
     const wbb = require('workbox-build')
-    wbb.generateSW({
+    await wbb.generateSW({
       swDest: path.resolve(outDir, 'service-worker.js'),
       globDirectory: outDir,
       globPatterns: ['**\/*.{js,css,html,png,jpg,jpeg,gif,svg,woff,woff2,eot,ttf,otf}']
     })
+    await fs.writeFile(
+      path.resolve(outDir, 'service-worker.js'),
+      await fs.readFile(path.resolve(__dirname, 'service-worker/skip-waiting.js'), 'utf8'),
+      { flag: 'a' }
+    )
   }
 
   // DONE.

--- a/lib/service-worker/skip-waiting.js
+++ b/lib/service-worker/skip-waiting.js
@@ -1,0 +1,12 @@
+addEventListener('message', event => {
+  const replyPort = event.ports[0]
+  const message = event.data
+  if (replyPort && message && message.type === 'skip-waiting') {
+    event.waitUntil(
+      self.skipWaiting().then(
+        () => replyPort.postMessage({ error: null }),
+        error => replyPort.postMessage({ error })
+      )
+    )
+  }
+})

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "portfinder": "^1.0.13",
     "postcss-loader": "^2.1.5",
     "prismjs": "^1.13.0",
-    "register-service-worker": "^1.2.0",
+    "register-service-worker": "^1.3.0",
     "semver": "^5.5.0",
     "stylus": "^0.54.5",
     "stylus-loader": "^3.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7022,7 +7022,7 @@ regexpu-core@^4.1.3, regexpu-core@^4.1.4:
     unicode-match-property-ecmascript "^1.0.3"
     unicode-match-property-value-ecmascript "^1.0.1"
 
-register-service-worker@^1.2.0:
+register-service-worker@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/register-service-worker/-/register-service-worker-1.3.0.tgz#02a0b7c40413b3c5ed1d801d764deb3aab1c3397"
 


### PR DESCRIPTION
Refs #453.

This PR adds the `e.skipWaiting()` method into the `sw-update` event in order to make that custom themes can implement reload buttons on the `sw-update` event.

**Background:**

I'm considering to use Vuepress to make the documentation of my OSSs. I will write the links to the documentation from changelogs. In the situation, Vuepress (with service workers) has a critical problem.

1. Browsers show the documentation from service worker caches when people open the documentation from the link in changelogs. It's old.
2. Reload doesn't work until all clients of the old service worker are closed.

So people have to open the documentation and close it and open it again in order to see the latest documentation. It's inconvenient.

Now Vuepress provides the `sw-update` event. It's the best timing to show "refresh" button to visitors in order to reload contents. However, new service worker doesn't available until they close all clients of the old service worker. Browsers will load contents from the old service worker even if it calls `location.reload(true)`. So I couldn't implement "refresh" button.

**Details:**

This PR adds the `e.skipWaiting()` method into the `sw-update` event to resolve that problem. The `e.skipWaiting()` method activates new service worker immediately. So we can reload contents after the `e.skipWaiting()` method is called. 

For example, [eslint-utils:/docs/.vuepress/theme/Layout.vue](https://github.com/mysticatea/eslint-utils/blob/89c9a6c146df0da1706e6f72919425a50e1618b8/docs/.vuepress/theme/Layout.vue) is an implementation of "refresh" button. If people clicked the "refresh" button, it calls the `e.skipWaiting()` method to available the new service worker then calls `location.reload(true)`.

**Notes:**

- This PR didn't implement the "refresh" button into the default theme because I don't have good idea about the way to configure the popup with internationalization.
- I'm not familiar with workbox. The `generateSW` method doesn't look to have the option which appends additional code. So I modified `build.js` to append a code to `service-worker.js` after workbox generated it. I'm not sure if this is good.