### PR TITLE
Support non ascii filename

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -15,6 +15,8 @@ footer: MIT Licensed | Copyright © 2018-present Evan You
 
 ### As Easy as 1, 2, 3
 
+[尤](./尤.md)
+
 ``` bash
 # install
 yarn global add vuepress # OR npm install -g vuepress

--- a/docs/guide/using-vue.md
+++ b/docs/guide/using-vue.md
@@ -1,4 +1,4 @@
-# Using Vue in Markdown
+# Using `Vue` in __Markdown__
 
 ## Browser API Access Restrictions
 

--- a/docs/guide/using-vue.md
+++ b/docs/guide/using-vue.md
@@ -1,4 +1,4 @@
-# Using `Vue` in __Markdown__
+# Using Vue in Markdown
 
 ## Browser API Access Restrictions
 

--- a/lib/app/Content.js
+++ b/lib/app/Content.js
@@ -1,5 +1,3 @@
-import { pathToComponentName } from './util'
-
 export default {
   functional: true,
 
@@ -11,7 +9,7 @@ export default {
   },
 
   render (h, { parent, props, data }) {
-    return h(pathToComponentName(parent.$page.path), {
+    return h(parent.$page.key, {
       class: [props.custom ? 'custom' : '', data.class, data.staticClass],
       style: data.style
     })

--- a/lib/app/app.js
+++ b/lib/app/app.js
@@ -67,6 +67,12 @@ export function createApp () {
 
   // redirect /foo to /foo/
   router.beforeEach((to, from, next) => {
+    const decodedPath = decodeURIComponent(to.path)
+    if (decodedPath !== to.path) {
+      next(Object.assign({}, to, {
+        path: decodedPath
+      }))
+    }
     if (!/(\/|\.html)$/.test(to.path)) {
       next(Object.assign({}, to, {
         path: to.path + '/'

--- a/lib/app/app.js
+++ b/lib/app/app.js
@@ -87,7 +87,6 @@ export function createApp () {
   // which will cause Vue-Router to match 404.
   let lastState
   window.addEventListener('popstate', event => {
-    console.log(event.state)
     if (event.state !== null && JSON.stringify(event.state) === JSON.stringify(lastState)) {
       history.back()
     }

--- a/lib/app/app.js
+++ b/lib/app/app.js
@@ -70,6 +70,7 @@ export function createApp () {
     const decodedPath = decodeURIComponent(to.path)
     if (decodedPath !== to.path) {
       next(Object.assign({}, to, {
+        fullPath: decodeURIComponent(to.fullPath),
         path: decodedPath
       }))
     }
@@ -81,6 +82,17 @@ export function createApp () {
       next()
     }
   })
+
+  // Fix when the two adjacent records in the browser's history contain same state, but have the different url,
+  // which will cause Vue-Router to match 404.
+  let lastState
+  window.addEventListener('popstate', event => {
+    console.log(event.state)
+    if (event.state !== null && JSON.stringify(event.state) === JSON.stringify(lastState)) {
+      history.back()
+    }
+    lastState = event.state
+  }, false)
 
   const options = {}
 

--- a/lib/app/app.js
+++ b/lib/app/app.js
@@ -85,12 +85,12 @@ export function createApp () {
 
   // Fix when the two adjacent records in the browser's history contain same state, but have the different url,
   // which will cause Vue-Router to match 404.
-  let lastState
+  let lastHistoryState
   window.addEventListener('popstate', event => {
-    if (event.state !== null && JSON.stringify(event.state) === JSON.stringify(lastState)) {
+    if (event.state !== null && JSON.stringify(event.state) === JSON.stringify(lastHistoryState)) {
       history.back()
     }
-    lastState = event.state
+    lastHistoryState = event.state
   }, false)
 
   const options = {}

--- a/lib/app/util.js
+++ b/lib/app/util.js
@@ -5,12 +5,9 @@ export function injectMixins (options, mixins) {
   options.mixins.push(...mixins)
 }
 
-export function pathToComponentName (path) {
-  if (path.charAt(path.length - 1) === '/') {
-    return `page${path.replace(/\//g, '-') + 'index'}`
-  } else {
-    return `page${path.replace(/\//g, '-').replace(/\.html$/, '')}`
-  }
+export function pathToComponentName (pages, path) {
+  const page = findPageForPath(pages, path)
+  return page && page.key
 }
 
 export function findPageForPath (pages, path) {

--- a/lib/default-theme/Layout.vue
+++ b/lib/default-theme/Layout.vue
@@ -94,7 +94,7 @@ export default {
     nprogress.configure({ showSpinner: false })
 
     this.$router.beforeEach((to, from, next) => {
-      if (to.path !== from.path && !Vue.component(pathToComponentName(to.path))) {
+      if (to.path !== from.path && !Vue.component(pathToComponentName(this.$site.pages, to.path))) {
         nprogress.start()
       }
       next()

--- a/lib/prepare.js
+++ b/lib/prepare.js
@@ -196,7 +196,9 @@ async function resolveOptions (sourceDir) {
   // resolve pagesData
   const pagesData = await Promise.all(pageFiles.map(async (file) => {
     const filepath = path.resolve(sourceDir, file)
+    const key = 'v-' + Math.random().toString(16).slice(2)
     const data = {
+      key,
       path: fileToPath(file)
     }
 
@@ -311,7 +313,7 @@ async function resolveComponents (sourceDir) {
 }
 
 async function genRoutesFile ({ siteData: { pages }, sourceDir, pageFiles }) {
-  function genRoute ({ path: pagePath }, index) {
+  function genRoute ({ path: pagePath, key: componentName }, index) {
     const file = pageFiles[index]
     const filePath = path.resolve(sourceDir, file)
     let code = `
@@ -320,7 +322,7 @@ async function genRoutesFile ({ siteData: { pages }, sourceDir, pageFiles }) {
     component: ThemeLayout,
     beforeEnter: (to, from, next) => {
       import(${JSON.stringify(filePath)}).then(comp => {
-        Vue.component(${JSON.stringify(fileToComponentName(file))}, comp.default)
+        Vue.component(${JSON.stringify(componentName)}, comp.default)
         next()
       })
     }


### PR DESCRIPTION
# Background

When using non-ASCII chars as filename, e.g. `尤.md`, there will be many issues.

# Fixed

- Currently VuePress will generate a invalid page component name: `page-尤.md`:

![image](https://user-images.githubusercontent.com/23133919/40297129-4d93f54e-5d11-11e8-8300-3d47e41ba0eb.png)

This PR leverage the random hash string prefixed with `v-` to generate the page component name.

- Close: #380: Support Chinese filename
- Close: #344: Vue-router's 404 error with chinese character in title
- Close: #307: Problem with sidebar links and history back button 
- Close: #433: Pages with non-ASCII chars in the url fail when opened directly



