### PR TITLE
feat: allow for disabling of active hash on scroll (#482)

### DIFF
--- a/docs/default-theme-config/README.md
+++ b/docs/default-theme-config/README.md
@@ -142,6 +142,18 @@ sidebarDepth: 2
 ---
 ```
 
+### Active Header Links
+
+By default, the nested header links and the hash in the URL are updated as the user scrolls to view the different sections of the page. This behavior can be disabled with the following theme config:
+
+``` js
+module.exports = {
+  themeConfig: {
+    disableActiveHash: true, // boolean
+  }
+}
+```
+
 ### Sidebar Groups
 
 You can divide sidebar links into multiple groups by using objects:

--- a/lib/default-theme/Layout.vue
+++ b/lib/default-theme/Layout.vue
@@ -136,6 +136,10 @@ export default {
       this.setActiveHash()
     }, 300),
     setActiveHash () {
+      if (this.$site.themeConfig.disableActiveHash) {
+        return
+      }
+
       const sidebarLinks = [].slice.call(document.querySelectorAll('.sidebar-link'))
       const anchors = [].slice.call(document.querySelectorAll('.header-anchor'))
         .filter(anchor => sidebarLinks.some(sidebarLink => sidebarLink.hash === anchor.hash))


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of default theme, please provide the **before/after** screenshot: 

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:

- [x] A convincing reason for adding this feature
- [x] Related documents have been updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**

Auto setting the active hash based on the side bar links and page headers was having some non-ideal behaviors on my site. If you have headers that aren't in the side bar, or update the hash programmatically this feature can cause issues.

I introduced a simple config to disable the capability.

Please not I'm open to suggestions, I opted to check the config in an isolated area related to the logic, but it still maintains the scroll listener which may not be optimal or preferred.