### PR TITLE
feat: support generic markdown file path reference

### DIFF
--- a/lib/markdown/link.js
+++ b/lib/markdown/link.js
@@ -2,6 +2,8 @@
 // 1. adding target="_blank" to external links
 // 2. converting internal links to <router-link>
 
+const indexRE = /(.*)(index|readme).md(#?.*)$/i
+
 module.exports = (md, externalAttrs) => {
   let hasOpenRouterLink = false
   let hasOpenExternalLink = false
@@ -37,13 +39,21 @@ module.exports = (md, externalAttrs) => {
     const links = md.__data.links || (md.__data.links = [])
     links.push(to)
 
-    to = to
-      .replace(/\.md$/, '.html')
-      .replace(/\.md(#.*)$/, '.html$1')
-    // normalize links to README/index
-    if (/^index|readme\.html/i.test(to)) {
-      to = '/'
+    const indexMatch = to.match(indexRE)
+    if (indexMatch) {
+      const [, path, , hash] = indexMatch
+      to = path + hash
+    } else {
+      to = to
+        .replace(/\.md$/, '.html')
+        .replace(/\.md(#.*)$/, '.html$1')
     }
+
+    // relative path usage.
+    if (!to.startsWith('/')) {
+      to = ensureBeginningDotSlash(to)
+    }
+
     // markdown-it encodes the uri
     link[1] = decodeURI(to)
     return Object.assign({}, token, {
@@ -64,4 +74,13 @@ module.exports = (md, externalAttrs) => {
     }
     return self.renderToken(tokens, idx, options)
   }
+}
+
+const beginningSlashRE = /^\.\//
+
+function ensureBeginningDotSlash (path) {
+  if (beginningSlashRE.test(path)) {
+    return path
+  }
+  return './' + path
 }

--- a/lib/markdown/link.js
+++ b/lib/markdown/link.js
@@ -56,6 +56,11 @@ module.exports = (md, externalAttrs) => {
 
     // markdown-it encodes the uri
     link[1] = decodeURI(to)
+
+    // export the router links for testing
+    const routerLinks = md.__data.routerLinks || (md.__data.routerLinks = [])
+    routerLinks.push(to)
+
     return Object.assign({}, token, {
       tag: 'router-link'
     })

--- a/test/markdown/__snapshots__/link.spec.js.snap
+++ b/test/markdown/__snapshots__/link.spec.js.snap
@@ -1,0 +1,25 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`link should render external links correctly 1`] = `
+<p>
+  <a href="https://vuejs.org/" target="_blank" rel="noopener noreferrer">vue
+    <OutboundLink/>
+  </a>
+</p>
+`;
+
+exports[`link should render external links correctly 2`] = `
+<p>
+  <a href="http://vuejs.org/" target="_blank" rel="noopener noreferrer">vue
+    <OutboundLink/>
+  </a>
+</p>
+`;
+
+exports[`link should render external links correctly 3`] = `
+<p>
+  <a href="https://google.com" target="_blank" rel="noopener noreferrer">some <strong>link</strong> with <code>code</code>
+    <OutboundLink/>
+  </a>
+</p>
+`;

--- a/test/markdown/link.spec.js
+++ b/test/markdown/link.spec.js
@@ -2,11 +2,15 @@ import { Md } from './util'
 import link from '@/markdown/link.js'
 import { dataReturnable } from '@/markdown/index.js'
 
-const mdL = Md().use(link)
+const mdL = Md().use(link, {
+  target: '_blank',
+  rel: 'noopener noreferrer'
+})
+
 dataReturnable(mdL)
 
-const asserts = {
-  // abosolute path usage
+const internalLinkAsserts = {
+  // START abosolute path usage
   '/': '/',
 
   '/foo/': '/foo/',
@@ -14,8 +18,9 @@ const asserts = {
 
   '/foo/two.md': '/foo/two.html',
   '/foo/two.html': '/foo/two.html',
+  // END abosolute path usage
 
-  // relative path usage
+  // START relative path usage
   'README.md': './',
   './README.md': './',
 
@@ -39,15 +44,29 @@ const asserts = {
 
   '../foo/one.md': './../foo/one.html',
   '../foo/one.md#hash': './../foo/one.html#hash'
+  // END relative path usage
 }
+
+const externalLinks = [
+  '[vue](https://vuejs.org/)',
+  '[vue](http://vuejs.org/)',
+  '[some **link** with `code`](https://google.com)' // #496
+]
 
 describe('link', () => {
   test('should convert internal links to router links correctly', () => {
-    for (const before in asserts) {
+    for (const before in internalLinkAsserts) {
       const input = `[${before}](${before})`
       const output = mdL.render(input)
       const after = getCompiledLink(output)
-      expect(after).toBe(asserts[before])
+      expect(after).toBe(internalLinkAsserts[before])
+    }
+  })
+
+  test('should render external links correctly', () => {
+    for (const link of externalLinks) {
+      const { html } = mdL.render(link)
+      expect(html).toMatchSnapshot()
     }
   })
 })

--- a/test/markdown/link.spec.js
+++ b/test/markdown/link.spec.js
@@ -1,0 +1,58 @@
+import { Md } from './util'
+import link from '@/markdown/link.js'
+import { dataReturnable } from '@/markdown/index.js'
+
+const mdL = Md().use(link)
+dataReturnable(mdL)
+
+const asserts = {
+  // abosolute path usage
+  '/': '/',
+
+  '/foo/': '/foo/',
+  '/foo/#hash': '/foo/#hash',
+
+  '/foo/two.md': '/foo/two.html',
+  '/foo/two.html': '/foo/two.html',
+
+  // relative path usage
+  'README.md': './',
+  './README.md': './',
+
+  'index.md': './',
+  './index.md': './',
+
+  'one.md': './one.html',
+  './one.md': './one.html',
+
+  'foo/README.md': './foo/',
+  './foo/README.md': './foo/',
+
+  'foo/README.md#hash': './foo/#hash',
+  './foo/README.md#hash': './foo/#hash',
+
+  '../README.md': './../',
+  '../README.md#hash': './../#hash',
+
+  '../foo.md': './../foo.html',
+  '../foo.md#hash': './../foo.html#hash',
+
+  '../foo/one.md': './../foo/one.html',
+  '../foo/one.md#hash': './../foo/one.html#hash'
+}
+
+describe('link', () => {
+  test('should convert internal links to router links correctly', () => {
+    for (const before in asserts) {
+      const input = `[${before}](${before})`
+      const output = mdL.render(input)
+      const after = getCompiledLink(output)
+      expect(after).toBe(asserts[before])
+    }
+  })
+})
+
+function getCompiledLink (output) {
+  const { data: { routerLinks }} = output
+  return routerLinks[0]
+}


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

cc @yyx990803.

# Summary

###  Reproduction Link
 
- https://vue-test-utils.vuejs.org/api/#mount (Click: `See also:Wrapper`, it will go to homepage.)
- http://www.v2js.com/vuepress-link/ (This link gives all possible situations)

## Reproduction

Assuming you have following directory structure:

``` md.
docs
├── README.md
└── guide
    ├── README.md
    ├── item-1.md
    └── item-2.md
```

When you use `[~](guide/README.md)` at `docs/README.md`, the expected output href should be `/guide/` instead of `/`.

Also, when you use `[~](README.md)`  at `docs/guide/item-1.md`, the expected output href should be `/guide/` instead of `/`.

With this PR, you can even use `../`.

## More

This PR also supports the usage of relative paths for all cases and doesn't force a absolute paths beginning with `/`. so vuepress's intrusion on md files has also been reduced to a minimum. You can safely migrate to vuepress from other static website builders without having to modify the links in the markdown file。

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of default theme, please provide the **before/after** screenshot: 

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

You have tested in the following browsers: (Providing a detailed version will be better.)

- [x] Chrome
- [x] Firefox
- [x] Safari
- [ ] Edge
- [ ] IE

If adding a **new feature**, the PR's description includes:

- [x] A convincing reason for adding this feature
- [ ] Related documents have been updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
