### PR TITLE
fix: increase sidebar-heading padding

### DIFF
--- a/lib/default-theme/SidebarGroup.vue
+++ b/lib/default-theme/SidebarGroup.vue
@@ -45,7 +45,7 @@ export default {
   font-size 1.1em
   font-weight bold
   // text-transform uppercase
-  padding-left 1.5rem
+  padding 0 1.5rem
   margin-top 0
   margin-bottom 0.5rem
   &.open, &:hover


### PR DESCRIPTION
Add padding to both sides of .sidebar-heading instead of left only

<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of default theme, please provide the **before/after** screenshot: 

**Before:**
![Before screenshot](https://i.imgur.com/OCL2P4J.png)

**After:**
![After screenshot](https://i.imgur.com/HubmxBi.png)

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

You have tested in the following browsers: (Providing a detailed version will be better.)

- [x] Chrome _Chromium Version 66.0.3359.181_
- [x] Firefox _Version 60.0_
- [x] Safari _Version 11.1 (13605.1.33.1.4)_
- [x] Edge _Version 42.17134.1.0_
- [x] IE _Version 11.540.15063.0_

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature
- [ ] Related documents have been updated
- [ ] Related tests have been updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
