### PR TITLE
feat: better sidebar transition

### DIFF
--- a/lib/default-theme/Sidebar.vue
+++ b/lib/default-theme/Sidebar.vue
@@ -1,6 +1,5 @@
 <template>
   <div class="sidebar">
-    <slot name="header"/>
     <NavLinks/>
     <slot name="top"/>
     <ul class="sidebar-links" v-if="items.length">

--- a/lib/default-theme/Sidebar.vue
+++ b/lib/default-theme/Sidebar.vue
@@ -1,5 +1,6 @@
 <template>
   <div class="sidebar">
+    <slot name="header"/>
     <NavLinks/>
     <slot name="top"/>
     <ul class="sidebar-links" v-if="items.length">

--- a/lib/default-theme/styles/mobile.styl
+++ b/lib/default-theme/styles/mobile.styl
@@ -14,17 +14,20 @@ $mobileSidebarWidth = $sidebarWidth * 0.82
 @media (max-width: $MQMobile)
   .sidebar
     top 0
+    bottom unset
+    height 100%
     padding-top .5rem
     box-shadow 0 0 10px rgba(0,0,0,0.2)
     transition transform 0.4s cubic-bezier(0.4, 0, 0, 1)
-    transform translateX(-105%)
+    transform translate3d(-105%, 0, 0)
     backface-visibility hidden
+
   .page
     padding-left 0
   .theme-container
     &.sidebar-open
       .sidebar
-        transform translateX(0)
+        transform translate3d(0, 0, 0)
     &.no-navbar
       .sidebar
         padding-top: 0

--- a/lib/default-theme/styles/mobile.styl
+++ b/lib/default-theme/styles/mobile.styl
@@ -14,9 +14,10 @@ $mobileSidebarWidth = $sidebarWidth * 0.82
 @media (max-width: $MQMobile)
   .sidebar
     top 0
-    padding-top $navbarHeight
-    transform translateX(-100%)
-    transition transform .2s ease
+    padding-top .5rem
+    box-shadow: 0 0 10px rgba(0,0,0,0.2);
+    transition: transform 0.4s cubic-bezier(0.4, 0, 0, 1);
+    transform translateX(-105%)
   .page
     padding-left 0
   .theme-container

--- a/lib/default-theme/styles/mobile.styl
+++ b/lib/default-theme/styles/mobile.styl
@@ -15,9 +15,10 @@ $mobileSidebarWidth = $sidebarWidth * 0.82
   .sidebar
     top 0
     padding-top .5rem
-    box-shadow: 0 0 10px rgba(0,0,0,0.2);
-    transition: transform 0.4s cubic-bezier(0.4, 0, 0, 1);
+    box-shadow 0 0 10px rgba(0,0,0,0.2)
+    transition transform 0.4s cubic-bezier(0.4, 0, 0, 1)
     transform translateX(-105%)
+    backface-visibility hidden
   .page
     padding-left 0
   .theme-container

--- a/lib/default-theme/styles/theme.styl
+++ b/lib/default-theme/styles/theme.styl
@@ -22,7 +22,7 @@ body
 
 .navbar
   position fixed
-  z-index 20
+  z-index 8
   top 0
   left 0
   right 0
@@ -38,7 +38,8 @@ body
   left 0
   width 100vw
   height 100vh
-  display none
+  transition visibility .3s, background-color .3s
+  visibility hidden
 
 .sidebar
   font-size 15px
@@ -169,7 +170,8 @@ th, td
 .theme-container
   &.sidebar-open
     .sidebar-mask
-      display: block
+      visibility visible
+      //background-color rgba(0, 0, 0, .75)
   &.no-navbar
     .content:not(.custom) > h1, h2, h3, h4, h5, h6
         margin-top 1.5rem

--- a/lib/default-theme/styles/theme.styl
+++ b/lib/default-theme/styles/theme.styl
@@ -152,8 +152,8 @@ hr
 table
   border-collapse collapse
   margin 1rem 0
-  display: block
-  overflow-x: auto
+  display block
+  overflow-x auto
 
 tr
   border-top 1px solid #dfe2e5
@@ -171,7 +171,7 @@ th, td
   &.sidebar-open
     .sidebar-mask
       visibility visible
-      //background-color rgba(0, 0, 0, .75)
+      // background-color rgba(0, 0, 0, .75)
   &.no-navbar
     .content:not(.custom) > h1, h2, h3, h4, h5, h6
         margin-top 1.5rem


### PR DESCRIPTION
# Summary

This PR leverages the transition of [vue.js official website](https://vuejs.org/v2/guide/) and also enhances the mobile's style when sidebar slide in from the left side. **It hides header, which allows users to focus more on sidebar.**

### Before:
![option-0](https://user-images.githubusercontent.com/23133919/41118100-91db46cc-6ac1-11e8-8a09-85af81e34fff.gif)

### Option 1
![option-1](https://user-images.githubusercontent.com/23133919/41118101-922c1ade-6ac1-11e8-96d3-87aaaea5299d.gif)

Hmmm... the `box-shadow` looks not very good in this gif, this `box-shadow` is also migrated from official website. so add a extra static snapshot here:

![image](https://user-images.githubusercontent.com/23133919/41118448-8c43fdca-6ac2-11e8-989a-e85b6ae20b3a.png)


### Option 2
![option-2](https://user-images.githubusercontent.com/23133919/41118102-927b94a6-6ac1-11e8-9c6d-de917ae590dd.gif)

@yyx990803 which one do you prefer?