### PR TITLE
fix: multiple markdown tokens regexp

### DIFF
--- a/lib/util/parseHeaders.js
+++ b/lib/util/parseHeaders.js
@@ -13,9 +13,9 @@ const unescapeHtml = html => String(html)
   .replace(/&gt;/g, '>')
 
 const removeMarkdownToken = str => String(str)
-  .replace(/\[(.*)\]\(.*\)/, '$1')            // []()
-  .replace(/(`|\*\*|\*|_)(.*[^\\])\1/, '$2')  // `{t}` | *{t}* | **{t}** | _{t}_
-  .replace(/(\\)(\*|_|`)/g, '$2')             // remove escape char '\'
+  .replace(/\[(.*)\]\(.*\)/, '$1')              // []()
+  .replace(/(`|\*{1,3}|_)(.*?[^\\])\1/g, '$2')  // `{t}` | *{t}* | **{t}** | _{t}_
+  .replace(/(\\)(\*|_|`)/g, '$2')               // remove escape char '\'
 
 exports.removeTailHtml = (str) => {
   return String(str).replace(/<.*>\s*$/g, '')

--- a/lib/util/parseHeaders.js
+++ b/lib/util/parseHeaders.js
@@ -14,7 +14,7 @@ const unescapeHtml = html => String(html)
 
 const removeMarkdownToken = str => String(str)
   .replace(/\[(.*)\]\(.*\)/, '$1')              // []()
-  .replace(/(`|\*{1,3}|_)(.*?[^\\])\1/g, '$2')  // `{t}` | *{t}* | **{t}** | _{t}_
+  .replace(/(`|\*{1,3}|_)(.*?[^\\])\1/g, '$2')  // `{t}` | *{t}* | **{t}** | ***{t}*** | _{t}_
   .replace(/(\\)(\*|_|`)/g, '$2')               // remove escape char '\'
 
 exports.removeTailHtml = (str) => {


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

Fixes issue for bold and italic text in headers  as well as multiple sets of tokens 
```markdown
# `keyword1` and `keyword2`
# ***bold and italic***
# **bold** and *italic*
```

Currently, only the one set of tokens is removed from the table of contents and sidebar links:

<img width="208" alt="screen shot 2018-06-09 at 9 56 41 pm" src="https://user-images.githubusercontent.com/15240680/41197858-15beb824-6c30-11e8-80e6-8a8be0bd6327.png">

Change makes the regexp non-greedy for matching the token pairs (`*?`) and matches up to 3 pairs of asterisks (`\*{1,3}`). 

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of default theme, please provide the **before/after** screenshot: 

N/A

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

You have tested in the following browsers: (Providing a detailed version will be better.)

- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
- [x] IE

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature
- [ ] Related documents have been updated
- [ ] Related tests have been updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
