### PR TITLE
fix: edit page from Bitbucket

### DIFF
--- a/lib/default-theme/Page.vue
+++ b/lib/default-theme/Page.vue
@@ -87,17 +87,8 @@ export default {
       } else {
         path += '.md'
       }
-
       if (docsRepo && editLinks) {
-        const base = outboundRE.test(docsRepo)
-          ? docsRepo
-          : `https://github.com/${docsRepo}`
-        return (
-          base.replace(endingSlashRE, '') +
-          `/edit/${docsBranch}` +
-          (docsDir ? '/' + docsDir.replace(endingSlashRE, '') : '') +
-          path
-        )
+        return this.createEditLink(repo, docsRepo, docsDir, docsBranch, path)
       }
     },
     editLinkText () {
@@ -105,6 +96,34 @@ export default {
         this.$themeLocaleConfig.editLinkText ||
         this.$site.themeConfig.editLinkText ||
         `Edit this page`
+      )
+    }
+  },
+  methods: {
+    createEditLink (repo, docsRepo, docsDir, docsBranch, path) {
+      const bitbucket = /bitbucket.org/
+      if (bitbucket.test(repo)) {
+        const base = outboundRE.test(docsRepo)
+          ? docsRepo
+          : repo
+        return (
+          base.replace(endingSlashRE, '') +
+           `/${docsBranch}` +
+           (docsDir ? '/' + docsDir.replace(endingSlashRE, '') : '') +
+           path +
+           `?mode=edit&spa=0&at=${docsBranch}&fileviewer=file-view-default`
+        )
+      }
+
+      const base = outboundRE.test(docsRepo)
+        ? docsRepo
+        : `https://github.com/${docsRepo}`
+
+      return (
+        base.replace(endingSlashRE, '') +
+        `/edit/${docsBranch}` +
+        (docsDir ? '/' + docsDir.replace(endingSlashRE, '') : '') +
+        path
       )
     }
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8292,7 +8292,7 @@ vue-jest@^2.6.0:
     tsconfig "^7.0.0"
     vue-template-es2015-compiler "^1.6.0"
 
-vue-loader@^15.2.1:
+vue-loader@^15.2.4:
   version "15.2.4"
   resolved "https://registry.yarnpkg.com/vue-loader/-/vue-loader-15.2.4.tgz#a7b923123d3cf87230a8ff54a1c16d31a6c5dbb4"
   dependencies:


### PR DESCRIPTION
The edit page from Bitbucket (is used a GET request with some parameters) is different from Gitbhub ( add /edit ). For example:

Bitbucket: https://bitbucket.org/myrepo/bitbucket-vuepress/src/master/docs/README.md?mode=edit&spa=0&at=master (This not exist)

Github: https://github.com/vuejs/vuepress/edit/master/docs/README.md

For test I create a repository in Bitbucket with vuePress and worked!

<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of default theme, please provide the **before/after** screenshot: 

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

You have tested in the following browsers: (Providing a detailed version will be better.)

- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
- [ ] IE

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature
- [ ] Related documents have been updated
- [ ] Related tests have been updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
