### PR TITLE
allow markdown.config in config.yml fix #326

### DIFF
--- a/lib/markdown/index.js
+++ b/lib/markdown/index.js
@@ -50,6 +50,9 @@ module.exports = ({ markdown = {}} = {}) => {
 
   // apply user config
   if (markdown.config) {
+    if (typeof markdown.config === 'string') {
+      markdown.config = eval(markdown.config)
+    }
     markdown.config(md)
   }
 


### PR DESCRIPTION
* allow setup of `markdown.config` in `config.yml`

`markdown.config` is a `String` and not evaluated as a function if you use `config.yml`

```yaml
# .vuepress/config.yml
title: Awesome docs
description: Vuepress rocks
markdown:
  lineNumbers: true
  config: |
    md => {
      md.use(require('markdown-it-checkbox'))
      md.use(require('markdown-it-ins'))
      md.use(require('markdown-it-mark'))
    }
```

:link: https://github.com/vuejs/vuepress/issues/326

/cc @luminarious

---

<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [x] Build-related changes
- [ ] Other, please describe:

If changing the UI of default theme, please provide the **before/after** screenshot: 

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

You have tested in the following browsers: (Providing a detailed version will be better.)

- [x] Chrome
- [x] Firefox
- [x] Safari
- [ ] Edge
- [ ] IE

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature
- [ ] Related documents have been updated
- [ ] Related tests have been updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**

We aren't ecmascript pros. And we know `eval` is evil in some context. But we had no better idea… 
