### PR TITLE
allow Markdown plugins loading fix #585

### DIFF
--- a/packages/@vuepress/markdown/__tests__/plugin.spec.js
+++ b/packages/@vuepress/markdown/__tests__/plugin.spec.js
@@ -1,0 +1,24 @@
+import { Md } from './util'
+import ins from 'markdown-it-ins'
+import mark from 'markdown-it-mark'
+
+const mdP = Md().use(ins).use(mark)
+// const mdP = Md().set({
+//   markdown: {
+//     plugins: ['ins', 'mark']
+//   }
+// })
+
+const asserts = {
+  'Demo ++inserted++ text.': '<p>Demo <ins>inserted</ins> text.</p>\n',
+  'Demo ==marked== text.': '<p>Demo <mark>marked</mark> text.</p>\n'
+}
+
+describe('plugin', () => {
+  test('should convert markdown w/ custom plugins', () => {
+    for (const input in asserts) {
+      const output = mdP.render(input)
+      expect(output).toBe(asserts[input])
+    }
+  })
+})

--- a/packages/@vuepress/markdown/index.js
+++ b/packages/@vuepress/markdown/index.js
@@ -32,7 +32,8 @@ module.exports = (markdown = {}) => {
     toc,
     lineNumbers,
     beforeInstantiate,
-    afterInstantiate
+    afterInstantiate,
+    plugins
   } = markdown
 
   // allow user config slugify
@@ -116,6 +117,13 @@ module.exports = (markdown = {}) => {
   afterInstantiate && afterInstantiate(md)
 
   module.exports.dataReturnable(md)
+
+  if (plugins) {
+    markdown.plugins.forEach(function (plugin) {
+      plugin = plugin.replace('markdown-it-', '')
+      md.use(require(`markdown-it-${plugin}`))
+    })
+  }
 
   // expose slugify
   md.slugify = slugify

--- a/packages/docs/docs/guide/markdown.md
+++ b/packages/docs/docs/guide/markdown.md
@@ -263,6 +263,18 @@ It also supports [line highlighting](#line-highlighting-in-code-blocks):
 :::
 
 
+## Plugins
+
+VuePress uses [markdown-it](https://github.com/markdown-it/markdown-it) as the markdown renderer. You can further customize the `markdown-it` instance using the `markdown.plugins` option in `.vuepress/config.js`. The `markdown-it-` prefix is optional and can omit in the list.
+
+``` js
+module.exports = {
+  markdown: {
+    plugins: ['ins', 'mark']
+  }
+}
+```
+
 ## Advanced Configuration
 
 VuePress uses [markdown-it](https://github.com/markdown-it/markdown-it) as the markdown renderer. A lot of the extensions above are implemented via custom plugins. You can further customize the `markdown-it` instance using the `markdown` option in `.vuepress/config.js`:


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

`markdown.config` currently requires a javascript [function argument](https://vuepress.vuejs.org/guide/markdown.html#import-code-snippets). This is only manageable with a `config.js` setup. I would like to allow markdown plugin loading also from a `config.yml` file.

I would propose a `markdown.plugins` endpoint that requires an Array. See implementation example.

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [x] Build-related changes
- [ ] Other, please describe:

<!-- If changing the UI of default theme, please provide the **before/after** screenshot: -->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

You have tested in the following browsers: (Providing a detailed version will be better.)

- [x] Chrome
- [x] Firefox
- [x] Safari
- [ ] Edge
- [ ] IE

If adding a **new feature**, the PR's description includes:

- [x] A convincing reason for adding this feature
- [x] Related documents have been updated
- [ ] Related tests have been updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

🔗💬 #585 

**Other information:**
