### PR TITLE
Remove cursor style from nav link container

### DIFF
--- a/lib/default-theme/DropdownLink.vue
+++ b/lib/default-theme/DropdownLink.vue
@@ -54,6 +54,7 @@ export default {
 @import './styles/config.styl'
 
 .dropdown-wrapper
+  cursor pointer
   .dropdown-title
     display block
     &:hover

--- a/lib/default-theme/NavLinks.vue
+++ b/lib/default-theme/NavLinks.vue
@@ -108,7 +108,6 @@ export default {
     &:hover, &.router-link-active
       color $accentColor
   .nav-item
-    cursor pointer
     position relative
     display inline-block
     margin-left 1.5rem


### PR DESCRIPTION
**Summary**
The `.nav-item` div around each navbar link currently has an explicit `cursor: pointer` style. However it's slightly higher than its contained link. This makes the styling undesirable since it tricks the user into thinking that they could click there to follow the link.

1. This pull request removes that style. It remains present on the link itself through the user agent stylesheet.

2. Interactive nav items without any links (currently only dropdowns) should still be receiving their cursor style independently. This is also done by this pull request for the `.dropdown-wrapper` class.

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of default theme, please provide the **before/after** screenshot: 

Note how the cursor does not actually touch the link.

* Before:
  ![before](https://user-images.githubusercontent.com/1922624/42064315-124b4f62-7b36-11e8-82f9-bf5714b67cfb.png)
* After:
  ![after](https://user-images.githubusercontent.com/1922624/42064335-1da108a2-7b36-11e8-8f55-316741f4a82b.png)

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

> It doesn't.

You have tested in the following browsers: (Providing a detailed version will be better.)

- [x] Chrome
- [x] Firefox
- [x] Safari
- [x] Edge
- [x] IE

> <s>Not done since change is *really* trivial.</s> Done it anyway. Deploy preview makes things easy. 👍

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature
- [ ] Related documents have been updated
- [ ] Related tests have been updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

> Not a feature.