### PR TITLE
fix: set babelrc: false in babel-loader options

### DIFF
--- a/lib/webpack/createBaseConfig.js
+++ b/lib/webpack/createBaseConfig.js
@@ -165,6 +165,8 @@ module.exports = function createBaseConfig ({
         .use('babel-loader')
           .loader('babel-loader')
           .options({
+            // do not pick local project babel config
+            babelrc: false,
             presets: [
               require.resolve('@vue/babel-preset-app')
             ]


### PR DESCRIPTION
Prevents picking up local `.babelrc` file in projects.
Babel options can be configured with `chainWebpack` in config by doing
`config.module.rule('js').use('babel-loader').tap(options => ({
...options, plugins: [] }))`

I found this while adding live examples to vue-router docs

<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of default theme, please provide the **before/after** screenshot: 

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

You have tested in the following browsers: (Providing a detailed version will be better.)

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
- [ ] IE

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature
- [ ] Related documents have been updated
- [ ] Related tests have been updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
