### PR TITLE
fix: exclude dest folder from pageFiles (fixes #654)

### DIFF
--- a/lib/prepare/resolveOptions.js
+++ b/lib/prepare/resolveOptions.js
@@ -106,6 +106,12 @@ module.exports = async function resolveOptions (sourceDir) {
   const markdown = createMarkdown(siteConfig)
 
   // resolve pageFiles
+  const files = ['**/*.md', '!.vuepress', '!node_modules']
+  if (siteConfig.dest) {
+    // exclude dest folder from pageFiles
+    const outDirRelative = path.relative(sourceDir, outDir)
+    files.push('!' + siteConfig.dest)
+  }
   const pageFiles = sort(await globby(['**/*.md', '!.vuepress', '!node_modules'], { cwd: sourceDir }))
 
   // resolve lastUpdated

--- a/lib/prepare/resolveOptions.js
+++ b/lib/prepare/resolveOptions.js
@@ -110,9 +110,9 @@ module.exports = async function resolveOptions (sourceDir) {
   if (siteConfig.dest) {
     // exclude dest folder from pageFiles
     const outDirRelative = path.relative(sourceDir, outDir)
-    files.push('!' + siteConfig.dest)
+    files.push('!' + outDirRelative)
   }
-  const pageFiles = sort(await globby(['**/*.md', '!.vuepress', '!node_modules'], { cwd: sourceDir }))
+  const pageFiles = sort(await globby(files, { cwd: sourceDir }))
 
   // resolve lastUpdated
   const shouldResolveLastUpdated = (


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**
Fixes #654

Dest folder, if present in the config, gets excluded from pageFiles to prevent parsing errors if any .md file's present.

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix

**Does this PR introduce a breaking change?** (check one)

- [x] No

**The PR fulfills these requirements:**

- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)