### PR TITLE
fix: could not display py lang in code block

### DIFF
--- a/lib/default-theme/styles/code.styl
+++ b/lib/default-theme/styles/code.styl
@@ -95,7 +95,7 @@ div[class*="language-"]
       background-color $codeBgColor
 
 
-for lang in js ts html md vue css sass scss less stylus go java c sh yaml
+for lang in js ts html md vue css sass scss less stylus go java c sh yaml py
   div{'[class~="language-' + lang + '"]'}
     &:before
       content ('' + lang)


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

`py` could not display in the top right corner of code block

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of default theme, please provide the **before/after** screenshot: 

**Before**

![qq 20180801152728](https://user-images.githubusercontent.com/18205362/43507771-8fa5a58c-95a0-11e8-8026-a2fe4877ca06.png)

![qq 20180801152734](https://user-images.githubusercontent.com/18205362/43507792-9bdccb50-95a0-11e8-9d71-523d1971df72.png)

**After**

![qq 20180801152746](https://user-images.githubusercontent.com/18205362/43507798-a0924d28-95a0-11e8-8783-2c104ce917a2.png)


**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

You have tested in the following browsers: (Providing a detailed version will be better.)

- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
- [ ] IE

**Other information:**
