### PR TITLE
Generalized support for code highlighting

### DIFF
--- a/lib/default-theme/styles/code.styl
+++ b/lib/default-theme/styles/code.styl
@@ -95,7 +95,7 @@ div[class*="language-"]
       background-color $codeBgColor
 
 
-for lang in js ts html md vue css sass scss less stylus go java c sh yaml py
+for lang in $codeLang
   div{'[class~="language-' + lang + '"]'}
     &:before
       content ('' + lang)

--- a/lib/default-theme/styles/config.styl
+++ b/lib/default-theme/styles/config.styl
@@ -3,6 +3,7 @@ $accentColor = #3eaf7c
 $textColor = #2c3e50
 $borderColor = #eaecef
 $codeBgColor = #282c34
+$codeLang = js ts html md vue css sass scss less stylus go java c sh yaml py
 $arrowBgColor = #ccc
 
 // layout


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

PR-#690 introduces the addition of 'py' to help label python-highlighted code in a document. I extend this idea by creating a Stylus variable to represent all default labels, and can be easily changed via `override.styl`.

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of default theme, please provide the **before/after** screenshot: 

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

You have tested in the following browsers: (Providing a detailed version will be better.)

- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
- [ ] IE

If adding a **new feature**, the PR's description includes:

- [x] A convincing reason for adding this feature
- [ ] Related documents have been updated
- [ ] Related tests have been updated

**Reason**: Currently the default theme uses a list of labels (line 98 in `code.styl`) to determine which code blocks will include the label in the top right corner. I think moving this list into `config.styl` and assigning a variable (named `$codeLang`) is better for a couple of reasons:

1. Easy overriding by `override.styl`. I think everyone will have different use cases for Vuepress, so they may choose to use only certain code languages. For example, a front-end heavy documentation may use lots of js, ts, etc, whereas a back-end heavy documentation may use go, python, rust. 
2. Choosing only certain languages reduces the css footprint by a small amount.


To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
