### PR TITLE
enhancing DocSearch integration with language

### DIFF
--- a/docs/default-theme-config/README.md
+++ b/docs/default-theme-config/README.md
@@ -336,7 +336,7 @@ module.exports = {
 Unlike the [built-in search](#built-in-search) engine which works out of the box, [Algolia DocSearch](https://community.algolia.com/docsearch/) requires you to submit your site to them for indexing before it starts working. 
 :::
 
-For more options, refer to [Algolia DocSearch's documentation](https://github.com/algolia/docsearch#docsearch-options).
+For more options, refer to [Algolia DocSearch's documentation](https://community.algolia.com/docsearch/documentation/docsearch/introduction/).
 
 ## Last Updated
 


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**
We want to introduce [the new way DocSearch will handle search on different languages for vuepress](https://github.com/algolia/docsearch-configs/commit/85a5791e2f98755fce93ca35595c698e2c28a54f).

It will not more be needed to use the URL as it might introduce issue. We will grab it ourselves from the DOM (attribute `lang`).

You can now update the vuepress website (couldn't find the website's repo):

```html
<!-- at the end of the HEAD -->
<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.css" />

<!-- at the end of the BODY -->
<script type="text/javascript" src="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js"></script>
<script type="text/javascript"> docsearch({
  apiKey: '3a539aab83105f01761a137c61004d85',
  indexName: 'vuepress',
  inputSelector: '### REPLACE ME ####',
  algoliaOptions: { 'facetFilters': ["lang:$LANG"] },
  debug: false // Set debug to true if you want to inspect the dropdown
});
</script>
```
- Add a search input in your page if you don't have any yet. Then update the inputSelector value in JS snippet to a CSS selector that targets your search input field.

- Replace $LANG with the lang you want to search on.
   So as of today you have: `en-US`, `zh-CN`

**What kind of change does this PR introduce?** (check at least one)

- Feature
- Docs

We do update the Documentation's references. 

**Does this PR introduce a breaking change?** (check one)

- No

CC #686
