### PR TITLE
fix: redirect fail between '/routeName' and '/routeName/'  ( fix: 720)

### DIFF
--- a/lib/prepare/codegen.js
+++ b/lib/prepare/codegen.js
@@ -6,7 +6,7 @@ exports.genRoutesFile = async function ({
   sourceDir,
   pageFiles
 }) {
-  function genRoute ({ path: pagePath, key: componentName }, index) {
+  function genRoute ({ path: pagePath, key: componentName }, index, pages) {
     const file = pageFiles[index]
     const filePath = path.resolve(sourceDir, file)
     let code = `
@@ -14,6 +14,9 @@ exports.genRoutesFile = async function ({
     name: ${JSON.stringify(componentName)},
     path: ${JSON.stringify(pagePath)},
     component: ThemeLayout,
+    pathToRegexpOptions: {
+      strict: true
+    },
     beforeEnter: (to, from, next) => {
       import(${JSON.stringify(filePath)}).then(comp => {
         Vue.component(${JSON.stringify(componentName)}, comp.default)
@@ -37,6 +40,14 @@ exports.genRoutesFile = async function ({
     path: ${JSON.stringify(pagePath + 'index.html')},
     redirect: ${JSON.stringify(pagePath)}
   }`
+      const dirPath = pagePath.replace(/\/$/, '')
+      if (!pages.find(page => page.path === `${dirPath}.html`) && dirPath) {
+        code += `,
+  {
+    path: ${JSON.stringify(dirPath)},
+    redirect: ${JSON.stringify(pagePath)}
+  }`
+      }
     }
 
     return code


### PR DESCRIPTION
<!-- Please don't delete this template -->

**Summary**

This is my issue here, [failed to redirect from '/routePath' to '/routePath/'](https://github.com/vuejs/vuepress/issues/720)

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**The PR fulfills these requirements:**

- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

You have tested in the following browsers: (Providing a detailed version will be better.)

- [x] Chrome
- [ ] Firefox
- [x] Safari
- [ ] Edge
- [ ] IE