### PR TITLE
feat: expose config.styl variables to style.styl

### DIFF
--- a/docs/default-theme-config/README.md
+++ b/docs/default-theme-config/README.md
@@ -476,6 +476,7 @@ $textColor = red
 
 ``` stylus
 // .vuepress/style.styl, your extra styles.
+// variables from config.styl can be used here
 #my-style {}
 ```
 

--- a/lib/prepare/index.js
+++ b/lib/prepare/index.js
@@ -28,9 +28,10 @@ module.exports = async function prepare (sourceDir) {
   const hasUserOverride = fs.existsSync(overridePath)
   await writeTemp('override.styl', hasUserOverride ? `@import(${JSON.stringify(overridePath)})` : ``)
 
+  const configPath = require.resolve('../default-theme/styles/config.styl')
   const stylePath = path.resolve(sourceDir, '.vuepress/style.styl').replace(/[\\]+/g, '/')
   const hasUserStyle = fs.existsSync(stylePath)
-  await writeTemp('style.styl', hasUserStyle ? `@import(${JSON.stringify(stylePath)})` : ``)
+  await writeTemp('style.styl', hasUserStyle ? `@import(${JSON.stringify(configPath)})\n@import(${JSON.stringify(stylePath)})` : ``)
 
   // Temporary tip, will be removed at next release.
   if (hasUserOverride && !hasUserStyle) {


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

Hello @ulivz, it's been a while! I just came back from holiday and looks like there are a lot of things happened in VuePress! All very exciting and looking cool! Thank you so much for the hard work! ❤️

Just a quick suggestion after upgrading to the latest VuePress. 

**Summary**
Referring to `config.styl` variables inside `style.styl` is probably a common thing. E.g. Useful for media query, text colors etc...

I think it makes sense if we expose the variables in `style.styl` by default.

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [x] Docs
- [x] Build-related changes
- [ ] Other, please describe:

If changing the UI of default theme, please provide the **before/after** screenshot: 

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No