### PR TITLE
feat: linkify in markdown-it

### DIFF
--- a/lib/markdown/index.js
+++ b/lib/markdown/index.js
@@ -19,6 +19,7 @@ module.exports = ({ markdown = {}} = {}) => {
 
   const md = require('markdown-it')({
     html: true,
+    linkify: true,
     highlight
   })
     // custom plugins


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**
It is pretty common for markdown processor to automatically "linkify" links in markdown. For instance, Github will convert this url to a link: https://vuepress.vuejs.org/

So I think it make total sense to add the [linkify option](https://github.com/markdown-it/markdown-it#linkify) in markdown-it to do that. It will save me a lot of time writing, e.g. `[https://vuepress.vuejs.org/](https://vuepress.vuejs.org/)`.

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [x] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No