### PR TITLE
feat: Sidebar toggle.

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -1,6 +1,5 @@
 module.exports = {
   dest: 'vuepress',
-  host: '0.0.0.0',
   locales: {
     '/': {
       lang: 'en-US',

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -1,5 +1,6 @@
 module.exports = {
   dest: 'vuepress',
+  host: '0.0.0.0',
   locales: {
     '/': {
       lang: 'en-US',
@@ -65,6 +66,10 @@ module.exports = {
           }
         ],
         sidebar: {
+          toggle: {
+            hideText: 'Hide sidebar',
+            showText: 'Show sidebar'
+          },
           '/guide/': genSidebarConfig('Guide')
         }
       },
@@ -98,6 +103,10 @@ module.exports = {
           }
         ],
         sidebar: {
+          toggle: {
+            hideText: '隐藏边栏',
+            showText: '显示侧边栏'
+          },
           '/zh/guide/': genSidebarConfig('指南')
         }
       }

--- a/lib/default-theme/Layout.vue
+++ b/lib/default-theme/Layout.vue
@@ -41,6 +41,7 @@
     <Page
       v-else
       :sidebar-items="sidebarItems"
+      ref="page"
     >
       <slot
         name="page-top"

--- a/lib/default-theme/Sidebar.vue
+++ b/lib/default-theme/Sidebar.vue
@@ -16,17 +16,19 @@
       </li>
     </ul>
     <slot name="bottom"/>
+    <SidebarToggle/>
   </div>
 </template>
 
 <script>
 import SidebarGroup from './SidebarGroup.vue'
 import SidebarLink from './SidebarLink.vue'
+import SidebarToggle from './SidebarToggle.vue'
 import NavLinks from './NavLinks.vue'
 import { isActive } from './util'
 
 export default {
-  components: { SidebarGroup, SidebarLink, NavLinks },
+  components: { SidebarGroup, SidebarLink, SidebarToggle, NavLinks },
 
   props: ['items'],
 

--- a/lib/default-theme/SidebarToggle.vue
+++ b/lib/default-theme/SidebarToggle.vue
@@ -1,0 +1,142 @@
+<template>
+  <div
+    class="sidebar__toggle"
+    v-if="!isMobile() && !isToggleHidden">
+    <span class="arrow"
+      :class="[isSidebarHidden ? 'right' : 'left']"/>
+    <span class="sidebar__toggle-label" @click="toggleSidebar()">
+      {{ isSidebarHidden ? this.showTextLabel : this.hideTextLabel }}
+    </span>
+  </div>
+</template>
+
+<script>
+export default {
+  data () {
+    return {
+      isSidebarHidden: false,
+      isToggleHidden: false,
+      pageClassList: null,
+      sidebarClassList: null,
+      showTextLabel: null,
+      hideTextLabel: null
+    }
+  },
+  methods: {
+    getSidebarToggleLabels () {
+      try {
+        this.showTextLabel = this.$themeLocaleConfig.sidebar.toggle.showText
+        this.hideTextLabel = this.$themeLocaleConfig.sidebar.toggle.hideText
+      }
+      catch {
+        this.showTextLabel = 'Show sidebar'
+        this.hideTextLabel = 'Hide sidebar'
+      }
+    },
+    setPageClassList () {
+      this.pageClassList = this.$parent.$parent.$refs.page.$el.classList
+    },
+    setSidebarClassList () {
+      this.sidebarClassList = this.$parent.$el.classList
+    },
+    toggleSidebar () {
+      this.setPageClassList()
+      this.setSidebarClassList()
+
+      if (this.isSidebarHidden) {
+        this.sidebarClassList.remove('shrink')
+        this.pageClassList.remove('widen')
+      } else {
+        this.sidebarClassList.add('shrink')
+        this.pageClassList.add('widen')
+      }
+
+      this.isSidebarHidden = !this.isSidebarHidden
+    },
+    isMobile () {
+      if (navigator.userAgent.match(/Android/i) ||
+        navigator.userAgent.match(/webOS/i) ||
+        navigator.userAgent.match(/iPhone/i) ||
+        navigator.userAgent.match(/iPad/i) ||
+        navigator.userAgent.match(/iPod/i) ||
+        navigator.userAgent.match(/BlackBerry/i) ||
+        navigator.userAgent.match(/Windows Phone/i)
+      ) {
+        return true
+      } else {
+        return false
+      }
+    }
+  },
+  mounted () {
+    this.getSidebarToggleLabels()
+  },
+  watch: {
+    '$route' () {
+      if (!Object.keys(this.$site.themeConfig.locales).includes(this.$route.path)) {
+        this.setPageClassList()
+        this.setSidebarClassList()
+        this.getSidebarToggleLabels()
+        if (this.sidebarClassList.contains('shrink')) {
+          this.pageClassList.add('widen')
+        }
+      }
+    }
+  }
+}
+</script>
+
+<style lang="stylus">
+@import './styles/config.styl'
+
+.page
+  transition all .2s ease
+  &.widen
+    padding-left 0rem
+
+.content
+  position relative
+
+.sidebar
+  white-space nowrap
+  transition all .2s ease
+
+  &__toggle
+    transition all .2s ease
+    padding-right .25rem
+    display inline-block
+    position fixed
+    top 0
+    left 16.4rem
+    height 100%
+    writing-mode vertical-lr
+    text-align center
+    @media (min-width: $MQNarrow)
+      left 20rem
+
+    &-label
+      cursor pointer
+      font-size small
+      font-weight 500
+      color lighten($textColor, 25%)
+      margin-left .25rem
+
+  &.shrink
+    margin-left -16.4rem
+    @media (min-width: $MQNarrow)
+      margin-left -20rem
+    & > ^[0]__toggle
+      transition all .2s ease
+      left 0
+      
+
+::-webkit-scrollbar
+    width 5px
+    height @width
+
+::-webkit-scrollbar-track
+    background $borderColor
+
+::-webkit-scrollbar-thumb
+    background $accentColor
+</style>

--- a/lib/default-theme/SidebarToggle.vue
+++ b/lib/default-theme/SidebarToggle.vue
@@ -1,7 +1,7 @@
 <template>
   <div
     class="sidebar__toggle"
-    v-if="!isMobile() && !isToggleHidden">
+    v-if="!isToggleHidden">
     <span class="arrow"
       :class="[isSidebarHidden ? 'right' : 'left']"/>
     <span class="sidebar__toggle-label" @click="toggleSidebar()">
@@ -53,20 +53,6 @@ export default {
 
       this.isSidebarHidden = !this.isSidebarHidden
     },
-    isMobile () {
-      if (navigator.userAgent.match(/Android/i) ||
-        navigator.userAgent.match(/webOS/i) ||
-        navigator.userAgent.match(/iPhone/i) ||
-        navigator.userAgent.match(/iPad/i) ||
-        navigator.userAgent.match(/iPod/i) ||
-        navigator.userAgent.match(/BlackBerry/i) ||
-        navigator.userAgent.match(/Windows Phone/i)
-      ) {
-        return true
-      } else {
-        return false
-      }
-    }
   },
   mounted () {
     this.getSidebarToggleLabels()


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

**What kind of change does this PR introduce?**

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

**Tested in the following browsers:**

- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge
- [ ] IE

**Other information:**
This change enables to toggle sidebar when in desktop mode. It also styles default scrollbars in chrome and safari.
Default label is 'Hide/Show sidebar'. To change it modify config.js to:
```
sidebar: {
    toggle: {
        hideText: 'Ukryj menu',
        showText: 'Pokaż menu'
    },
}
```
![Preview](https://user-images.githubusercontent.com/25805810/44527317-bee27080-a6e6-11e8-959a-e8cc013ebd2a.png)
