### PR TITLE
Blog stage 1 - permalink

### DIFF
--- a/packages/@vuepress/core/lib/internal-plugins/routes.js
+++ b/packages/@vuepress/core/lib/internal-plugins/routes.js
@@ -17,12 +17,12 @@ async function genRoutesFile (pages) {
   function genRoute ({
     path: pagePath,
     key: componentName,
-    frontmatter = {}
+    regularPath
   }) {
     let code = `
   {
     name: ${JSON.stringify(componentName)},
-    path: ${JSON.stringify(frontmatter.permalink || pagePath)},
+    path: ${JSON.stringify(pagePath)},
     component: ThemeLayout,
     beforeEnter: (to, from, next) => {
       registerComponent(${JSON.stringify(componentName)}).then(() => next())
@@ -42,6 +42,14 @@ async function genRoutesFile (pages) {
       code += `,
   {
     path: ${JSON.stringify(pagePath + 'index.html')},
+    redirect: ${JSON.stringify(pagePath)}
+  }`
+    }
+
+    if (regularPath !== pagePath) {
+      code += `,
+  {
+    path: ${JSON.stringify(regularPath)},
     redirect: ${JSON.stringify(pagePath)}
   }`
     }

--- a/packages/@vuepress/core/lib/prepare/AppContext.js
+++ b/packages/@vuepress/core/lib/prepare/AppContext.js
@@ -149,7 +149,11 @@ module.exports = class AppContext {
    */
   async addPage (filePath, { relative, permalink }) {
     const page = new Page(filePath, { relative, permalink })
-    await page.process(this.markdown, new this.I18nConstructor((this.getSiteData.bind(this))))
+    await page.process(
+      this.markdown,
+      this.siteConfig.permalink,
+      new this.I18nConstructor((this.getSiteData.bind(this))),
+    )
     await this.pluginAPI.options.extendPageData.apply(page)
     this.pages.push(page)
   }

--- a/packages/@vuepress/core/lib/prepare/Page.js
+++ b/packages/@vuepress/core/lib/prepare/Page.js
@@ -1,7 +1,7 @@
 const path = require('path')
 const slugify = require('../markdown/slugify')
 const { fs } = require('@vuepress/shared-utils')
-const { fileToPath } = require('./util')
+const { fileToPath, getPermalink } = require('./util')
 const {
   inferTitle,
   extractHeaders,
@@ -19,10 +19,10 @@ module.exports = class Page {
     } else if (permalink) {
       this._routePath = encodeURI(permalink)
     }
-    this.path = this._routePath
+    this.regularPath = this.path = this._routePath
   }
 
-  async process (markdown, i18n) {
+  async process (markdown, permalinkPattern, i18n) {
     this.key = 'v-' + Math.random().toString(16).slice(2)
     this._content = await fs.readFile(this._filePath, 'utf-8')
     const frontmatter = parseFrontmatter(this._content)
@@ -53,6 +53,18 @@ module.exports = class Page {
     // resolve i18n
     i18n.setSSRContext(this)
     this._i18n = i18n
+
+    this.permalink = getPermalink({
+      pattern: this.frontmatter.permalink || permalinkPattern,
+      slug: this.slug,
+      date: this.frontmatter.date,
+      localePath: i18n.$localePath,
+      regularPath: this.regularPath
+    })
+
+    if (this.permalink) {
+      this.path = this.permalink
+    }
   }
 
   get filename () {

--- a/packages/@vuepress/core/lib/prepare/util.js
+++ b/packages/@vuepress/core/lib/prepare/util.js
@@ -24,3 +24,52 @@ exports.sort = function (arr) {
     return 0
   })
 }
+
+// e.g.
+// filename: docs/_posts/evanyou.md
+// content: # yyx 990803
+// date: 2018-08-14 11:22:33
+// :year/:month/:day/:slug/ => 2018/08/14/yyx-990803/
+// :year-:month-:day-:slug/ => 2018-08-14-yyx-990803/
+// :year/:month/:day/:title/ => 2018/08/14/yyx 990803/
+// :year/:month/:day/:original/ => 2018/08/14/_posts/evanyou.html
+
+exports.getPermalink = function ({
+  pattern,
+  slug,
+  date,
+  regularPath,
+  localePath
+}) {
+  if (!pattern) {
+    return
+  }
+  slug = encodeURI(slug)
+
+  const d = new Date(date)
+  const year = d.getFullYear()
+  const iMonth = d.getMonth() + 1
+  const iDay = d.getDate()
+  const minutes = d.getMinutes()
+  const seconds = d.getSeconds()
+  const month = iMonth < 10 ? `0${iMonth}` : iMonth
+  const day = iDay < 10 ? `0${iDay}` : iDay
+
+  // Remove leading slash
+  pattern = pattern.replace(/^\//, '')
+
+  const link =
+    localePath +
+    pattern
+      .replace(/:year/, year)
+      .replace(/:month/, month)
+      .replace(/:i_month/, iMonth)
+      .replace(/:i_day/, iDay)
+      .replace(/:day/, day)
+      .replace(/:minutes/, minutes)
+      .replace(/:seconds/, seconds)
+      .replace(/:slug/, slug)
+      .replace(/:regular/, regularPath)
+
+  return link.replace(/^\/?/, '/')
+}

--- a/packages/@vuepress/core/lib/prepare/util.js
+++ b/packages/@vuepress/core/lib/prepare/util.js
@@ -71,5 +71,17 @@ exports.getPermalink = function ({
       .replace(/:slug/, slug)
       .replace(/:regular/, regularPath)
 
-  return link.replace(/^\/?/, '/')
+  return ensureLeadingSlash(
+    ensureEndingSlash(link)
+  )
+}
+
+function ensureLeadingSlash (path) {
+  return path.replace(/^\/?/, '/')
+}
+
+function ensureEndingSlash (path) {
+  return /(\.html|\/)$/.test(path)
+    ? path
+    : path + '/'
 }

--- a/packages/@vuepress/core/lib/prepare/util.js
+++ b/packages/@vuepress/core/lib/prepare/util.js
@@ -26,13 +26,13 @@ exports.sort = function (arr) {
 }
 
 // e.g.
-// filename: docs/_posts/evanyou.md
+// filename: docs/_posts/evan you.md
 // content: # yyx 990803
 // date: 2018-08-14 11:22:33
-// :year/:month/:day/:slug/ => 2018/08/14/yyx-990803/
-// :year-:month-:day-:slug/ => 2018-08-14-yyx-990803/
+// :year/:month/:day/:slug/ => 2018/08/14/evan-you/
+// :year-:month-:day-:slug/ => 2018-08-14-evan-you/
 // :year/:month/:day/:title/ => 2018/08/14/yyx 990803/
-// :year/:month/:day/:original/ => 2018/08/14/_posts/evanyou.html
+// :year/:month/:day/:original/ => 2018/08/14/_posts/evan you.html
 
 exports.getPermalink = function ({
   pattern,

--- a/packages/@vuepress/theme-default/src/Layout.vue
+++ b/packages/@vuepress/theme-default/src/Layout.vue
@@ -103,7 +103,7 @@ export default {
     sidebarItems () {
       return resolveSidebarItems(
         this.$page,
-        this.$route,
+        this.$page.regularPath,
         this.$site,
         this.$localePath
       )

--- a/packages/@vuepress/theme-default/src/Sidebar.vue
+++ b/packages/@vuepress/theme-default/src/Sidebar.vue
@@ -62,7 +62,7 @@ export default {
     },
 
     isActive (page) {
-      return isActive(this.$route, page.path)
+      return isActive(this.$route, page.regularPath)
     }
   }
 }

--- a/packages/@vuepress/theme-default/src/util.js
+++ b/packages/@vuepress/theme-default/src/util.js
@@ -59,10 +59,10 @@ export function resolvePage (pages, rawPath, base) {
   }
   const path = normalize(rawPath)
   for (let i = 0; i < pages.length; i++) {
-    if (normalize(pages[i].path) === path) {
+    if (normalize(pages[i].regularPath) === path) {
       return Object.assign({}, pages[i], {
         type: 'page',
-        path: ensureExt(rawPath)
+        path: ensureExt(pages[i].path)
       })
     }
   }
@@ -108,7 +108,14 @@ function resolvePath (relative, base, append) {
   return stack.join('/')
 }
 
-export function resolveSidebarItems (page, route, site, localePath) {
+/**
+ * @param { Page } page
+ * @param { string } regularPath
+ * @param { SiteData } site
+ * @param { string } localePath
+ * @returns { SidebarGroup }
+ */
+export function resolveSidebarItems (page, regularPath, site, localePath) {
   const { pages, themeConfig } = site
 
   const localeConfig = localePath && themeConfig.locales
@@ -124,13 +131,17 @@ export function resolveSidebarItems (page, route, site, localePath) {
   if (!sidebarConfig) {
     return []
   } else {
-    const { base, config } = resolveMatchingConfig(route, sidebarConfig)
+    const { base, config } = resolveMatchingConfig(regularPath, sidebarConfig)
     return config
       ? config.map(item => resolveItem(item, pages, base))
       : []
   }
 }
 
+/**
+ * @param { Page } page
+ * @returns { SidebarGroup }
+ */
 function resolveHeaders (page) {
   const headers = groupHeaders(page.headers || [])
   return [{
@@ -167,7 +178,12 @@ export function resolveNavLinkItem (linkItem) {
   })
 }
 
-export function resolveMatchingConfig (route, config) {
+/**
+ * @param { Route } route
+ * @param { Array<string|string[]> | Array<SidebarGroup> | [link: string]: SidebarConfig } config
+ * @returns { base: string, config: SidebarConfig }
+ */
+export function resolveMatchingConfig (regularPath, config) {
   if (Array.isArray(config)) {
     return {
       base: '/',
@@ -175,7 +191,7 @@ export function resolveMatchingConfig (route, config) {
     }
   }
   for (const base in config) {
-    if (ensureEndingSlash(route.path).indexOf(base) === 0) {
+    if (ensureEndingSlash(regularPath).indexOf(base) === 0) {
       return {
         base,
         config: config[base]

--- a/packages/docs/docs/guide/assets.md
+++ b/packages/docs/docs/guide/assets.md
@@ -1,3 +1,8 @@
+---
+permalink: :year/:month/:day/:slug/
+date: 2018-08-15 11:22:33
+---
+
 # Asset Handling
 
 ## Relative URLs

--- a/packages/docs/docs/guide/assets.md
+++ b/packages/docs/docs/guide/assets.md
@@ -1,5 +1,5 @@
 ---
-permalink: :year/:month/:day/:slug/
+permalink: :year/:month/:day/:slug
 date: 2018-08-15 11:22:33
 ---
 


### PR DESCRIPTION
# Summary

Permalinks refer to the URLs (excluding the domain name) for your pages and posts. 

**Demo**: 
[vuepress-permalink.zip](https://github.com/vuejs/vuepress/files/2315946/vuepress-permalink.zip)


## Note: Document contribution for this feature is open, welcome!

## Usage

1. Global (For blog)

```js
module.exports = {
    permalink: ':year/:month/:day/:slug'
}
```

2. Specific page

``` md
---
permalink: :year/:month/:day/:slug
date: 2018-08-14 11:22:33
---
```

## Example

- **sourceDir**: docs
- **filename**: docs/_posts/evan you.md
- **content**: 

   ``` md
   ---
   permalink: :year/:month/:day/:slug
   date: 2018-08-14 11:22:33
   ---

   # yyx 990803
   ```

- **asserts**: 

| pattern | permalink |
| --- | --- |
| :year/:month/:day/:slug/ | 2018/08/14/evan-you/ |
| :year-:month-:day-:slug/ | 2018-08-14-evan-you/ |
| :year/:month/:day/:title/ | 2018/08/14/yyx 990803/ |
| :year/:month/:day/:original/ | 2018/08/14/_posts/evan you.html |


## Variables

| Variable | Description |
|---|---|
|:year|Published year of posts (4-digit)|
|:month|Published month of posts (2-digit)|
|:i_month|Published month of posts (Without leading zeros)|
|:day|Published day of posts (2-digit)|
|:i_day|Published day of posts (Without leading zeros)|
|:slug|Slugified file path (Without extension)|
|:regular| Permalink generated by VuePress by default |