### PR TITLE
chore: do not need to export getLoggerFn

### DIFF
--- a/docs/default-theme-config/README.md
+++ b/docs/default-theme-config/README.md
@@ -358,7 +358,7 @@ Note that it's `off` by default. If given a `string`, it will be displayed as a 
 
 ## Service Worker
 
-The `themeConfig.serviceWorker` option allows you to configure about service worker.
+The `themeConfig.serviceWorker` option allows you to configure the service worker.
 
 ::: tip
 Please do not confuse this option with [Config > serviceWorker](../config/README.md#serviceworker), [Config > serviceWorker](../config/README.md#serviceworker) is **site-level**, while this option is **theme-level**.
@@ -366,7 +366,7 @@ Please do not confuse this option with [Config > serviceWorker](../config/README
 
 ### Popup UI to refresh contents <Badge text="0.13.0+"/> <Badge text="beta" type="warn"/>
 
-The `themeConfig.serviceWorker.updatePopup` option enables the popup to refresh contents. The popup will be shown when the site is updated (i.e. service worker is updated). It provides `refresh` button to allow users to refresh contents immediately.
+The `themeConfig.serviceWorker.updatePopup` option enables a popup to refresh site content. The popup will be shown when the site is updated (i.e. service worker is updated). It provides a `refresh` button to allow users to refresh contents immediately.
 
 ::: tip NOTE
 If without the `refresh` button, the new service worker will be active after all [clients](https://developer.mozilla.org/en-US/docs/Web/API/Clients) are closed. This means that visitors cannot see new contents until they close all tabs of your site. But the `refresh` button activates the new service worker immediately.

--- a/lib/util/logger.js
+++ b/lib/util/logger.js
@@ -45,4 +45,3 @@ for (const type in logTypes) {
 }
 
 module.exports = logger
-module.exports.getLoggerFn = getLoggerFn


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**
Remove `module.exports.getLoggerFn = getLoggerFn`.
After `logger[type] = getLoggerFn(color, label)`, this function doesn't execute anymore so I think there is no need to export getLoggerFn.
**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [x] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of default theme, please provide the **before/after** screenshot: 

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

You have tested in the following browsers: (Providing a detailed version will be better.)

- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
- [ ] IE

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature
- [ ] Related documents have been updated
- [ ] Related tests have been updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
