### PR TITLE
feat: add google analytics anonymizeIp in siteConfig

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ https://vuepress.vuejs.org/
 
 * [Multi-Language Support](https://vuepress.vuejs.org/guide/i18n.html)
 * [Service Worker](https://vuepress.vuejs.org/config/#serviceworker)
-* [Google Analytics](https://vuepress.vuejs.org/config/#ga)
+* [Google Analytics, with privacy setting](https://vuepress.vuejs.org/config/#ga)
 
 ## Showcase
 

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -79,7 +79,7 @@ Specify the output directory for `vuepress build`.
 
 Provide the Google Analytics ID as a string to enable integration.
 
-You can also use an object to enable IP anonymization:
+<Badge text="0.14.3+"/> You can also use an object to enable IP anonymization:
 
 ``` js
 module.exports = {

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -74,13 +74,25 @@ Specify the output directory for `vuepress build`.
 
 ### ga
 
-- Type: `string`
+- Type: `string | { id: string, anonymizeIp: boolean }`
 - Default: `undefined`
 
-Provide the Google Analytics ID to enable integration.
+Provide the Google Analytics ID as a string to enable integration.
+
+You can also use an object to enable IP anonymization:
+
+``` js
+module.exports = {
+  // …
+  ga: {
+    id: 'UA-XXXX-X',
+    anonymizeIp: true // false by default for backwards compatibility
+  }
+}
+```
 
 ::: tip
-Please be aware of [GDPR (2018 reform of EU data protection rules)](https://ec.europa.eu/commission/priorities/justice-and-fundamental-rights/data-protection/2018-reform-eu-data-protection-rules_en) and consider setting Google Analytics to [anonymize IPs](https://support.google.com/analytics/answer/2763052?hl=en) where appropriate and/or needed.
+Consider setting Google Analytics to [anonymize IPs](https://support.google.com/analytics/answer/2763052?hl=en) using `anonymizeIp: true` setting, to protect user privacy and comply with [GDPR (2018 reform of EU data protection rules)](https://ec.europa.eu/commission/priorities/justice-and-fundamental-rights/data-protection/2018-reform-eu-data-protection-rules_en).
 :::
 
 ### serviceWorker

--- a/lib/app/clientEntry.js
+++ b/lib/app/clientEntry.js
@@ -1,4 +1,4 @@
-/* global BASE_URL, GA_ID, ga, SW_ENABLED, VUEPRESS_VERSION, LAST_COMMIT_HASH*/
+/* global BASE_URL, GA_ID, GA_ANONYMIZE, ga, SW_ENABLED, VUEPRESS_VERSION, LAST_COMMIT_HASH*/
 
 import { createApp } from './app'
 import SWUpdateEvent from './SWUpdateEvent'
@@ -27,6 +27,13 @@ if (process.env.NODE_ENV === 'production' && GA_ID) {
   })(window, document, 'script', 'https://www.google-analytics.com/analytics.js', 'ga')
 
   ga('create', GA_ID, 'auto')
+
+  // Improved privacy: https://support.google.com/analytics/answer/2763052
+  if (GA_ANONYMIZE === true) {
+    ga('set', 'anonymizeIp', true)
+    ga('set', 'forceSSL', true)
+  }
+
   ga('send', 'pageview')
 
   router.afterEach(function (to) {

--- a/lib/webpack/createBaseConfig.js
+++ b/lib/webpack/createBaseConfig.js
@@ -289,11 +289,15 @@ module.exports = function createBaseConfig ({
   }
 
   // inject constants
+  const hasGaObjectConfig = typeof siteConfig.ga === 'object' && typeof siteConfig.ga.id === 'string'
   config
     .plugin('injections')
     .use(require('webpack/lib/DefinePlugin'), [{
       BASE_URL: JSON.stringify(siteConfig.base || '/'),
-      GA_ID: siteConfig.ga ? JSON.stringify(siteConfig.ga) : false,
+      GA_ID: hasGaObjectConfig
+        ? JSON.stringify(siteConfig.ga.id)
+        : (typeof siteConfig.ga === 'string' ? JSON.stringify(siteConfig.ga) : false),
+      GA_ANONYMIZE: hasGaObjectConfig && siteConfig.ga.anonymizeIp === true,
       SW_ENABLED: !!siteConfig.serviceWorker,
       VUEPRESS_VERSION: JSON.stringify(require('../../package.json').version),
       LAST_COMMIT_HASH: JSON.stringify(getLastCommitHash())


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

A tip about IP anonymization and GDPR was introduced in the docs (https://github.com/vuejs/vuepress/pull/515).

Privacy should be easy: this PR allows to set Google Analytics `anonymizeIp` option without having to write custom theme/code as previously [suggested](https://github.com/vuejs/vuepress/issues/539#issuecomment-409842121).

I would have gladly made this default since it has [little](https://www.conversionworks.co.uk/blog/2018/04/16/ip-anonymization-ga-impact-assessment/) impact on analytics accuracy but this would still be a breaking change and is left to `next` branch (ready to make another PR).

`ga` option can now be a string _or_ an object with `id` and `anonymize` optional boolean attribute defaulting to `false` as explained above.

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of default theme, please provide the **before/after** screenshot: 

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number) > **No issue**

You have tested in the following browsers: (Providing a detailed version will be better.)

- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge
- [ ] IE

If adding a **new feature**, the PR's description includes:

- [x] A convincing reason for adding this feature
- [x] Related documents have been updated
- [ ] Related tests have been updated > No test for Google Analytics (no debug version)

**Other information:**

I checked that `aip=1` is included in event requests (only) when using the option, as stated by [Google dedicated page](https://support.google.com/analytics/answer/2763052?hl=en).

![vuepress anonymizeip aip=](https://user-images.githubusercontent.com/12909094/45124749-c33d6d80-b16b-11e8-8e87-b910acd93890.png)
