### PR TITLE
Update deploy.md

### DIFF
--- a/docs/guide/deploy.md
+++ b/docs/guide/deploy.md
@@ -9,7 +9,7 @@ The following guides are based on a few shared assumptions:
 ``` json
 {
   "scripts": {
-    "docs:build": "vuepress build docs"
+    "docs:build": "vuepress build"
   }
 }
 ```


### PR DESCRIPTION
'vuepress build docs' overrides the 'dest' setting in .vuepress/config.js. The correct script should be 'vuepress build'.

<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [x] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No
