### PR TITLE
feat: add '.vudepress/static' folder for server static files

### DIFF
--- a/lib/dev.js
+++ b/lib/dev.js
@@ -109,6 +109,7 @@ module.exports = async function dev (sourceDir, cliOptions = {}) {
     port,
     add: app => {
       const userPublic = path.resolve(sourceDir, '.vuepress/public')
+      const userStatic = path.resolve(sourceDir, '.vuepress/static')
 
       // enable range request
       app.use(range)
@@ -116,6 +117,9 @@ module.exports = async function dev (sourceDir, cliOptions = {}) {
       // respect base when serving static files...
       if (fs.existsSync(userPublic)) {
         app.use(mount(options.publicPath, serveStatic(userPublic)))
+      }
+      if (fs.existsSync(userStatic)) {
+        app.use(mount('/', serveStatic(userStatic)))
       }
 
       app.use(convert(history({


### PR DESCRIPTION
<!-- Please don't delete this template -->
When we may to provide static assets, we put them inside '.vuepress/public'.
But I use server static files (not project root directory) for development.
This PR affect to dev only.

I don't mind if you change folder name "static'.

Thank you.


<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of default theme, please provide the **before/after** screenshot: 

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

You have tested in the following browsers: (Providing a detailed version will be better.)

- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
- [ ] IE

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature
- [ ] Related documents have been updated
- [ ] Related tests have been updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
