### PR TITLE
fix($core): useLocalTheme should be set to true when localThemePath exists and contains file

### DIFF
--- a/packages/@vuepress/core/lib/prepare/loadTheme.js
+++ b/packages/@vuepress/core/lib/prepare/loadTheme.js
@@ -10,7 +10,7 @@ module.exports = async function loadTheme (theme, sourceDir, vuepressDir) {
   // resolve theme
   const localThemePath = path.resolve(vuepressDir, 'theme')
   const useLocalTheme =
-    (await fs.exists(localThemePath)) && ((await fs.readdir(localThemePath)).length > 0)
+    fs.existsSync(localThemePath) && (fs.readdirSync(localThemePath)).length > 0
 
   let themePath = null         // Mandatory
   let themeIndexFile = null    // Optional


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of default theme, please provide the **before/after** screenshot: 

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

You have tested in the following browsers: (Providing a detailed version will be better.)

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
- [ ] IE

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature
- [ ] Related documents have been updated
- [ ] Related tests have been updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**

fs.exists() is [deprecated](https://nodejs.org/api/fs.html#fs_fs_exists_path_callback), and using it without a callback causes the error **TypeError [ERR_INVALID_CALLBACK]: Callback must be a function** on Node.js 10. Using fs.existsSync() also avoids these issues.