### PR TITLE
fix #855 Stop observing add/remove of files in node_modules

### DIFF
--- a/lib/dev.js
+++ b/lib/dev.js
@@ -35,7 +35,7 @@ module.exports = async function dev (sourceDir, cliOptions = {}) {
     '.vuepress/components/**/*.vue'
   ], {
     cwd: sourceDir,
-    ignored: '.vuepress/**/*.md',
+    ignored: ['.vuepress/**/*.md', 'node_modules'],
     ignoreInitial: true
   })
   pagesWatcher.on('add', update)


### PR DESCRIPTION
Closes #855

When running vuepress dev, chokidar is set to observe all
addition/removal of md files inside the current folder.

`node_modules` is one of the observed folders and can contain tons of subfolders. It mostly never contains any md files. Even more rarely has it any hot additions of md files.

Another perk of this fix is this: If for some reason a developer
decided to publish a folder with a weird name in its module. It will not
prevent `vuepress dev` from loading.

<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

**What kind of change does this PR introduce?** (check at least one)

- [X] Bugfix
- [X] Dev perf

If changing the UI of default theme, please provide the **before/after** screenshot: 

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [X] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

You have tested in the following browsers: (Providing a detailed version will be better.)

node 8.11.4

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
