### PR TITLE
🐛 fix #901 "vuepress eject not copying default theme files"

### DIFF
--- a/packages/@vuepress/core/lib/eject.js
+++ b/packages/@vuepress/core/lib/eject.js
@@ -9,7 +9,7 @@ module.exports = async (dir) => {
     console.log(chalk.red(`\n[vuepress] cannot find '@vuepress/theme-default'\n`))
     process.exit(1)
   }
-  const source = require.resolve('@vuepress/theme-default')
+  const source = require.resolve('@vuepress/theme-default').replace(/index\.js$/, '')
   const target = path.resolve(dir, '.vuepress/theme')
   await fs.copy(source, target)
   logger.success(`\nCopied default theme into ${chalk.cyan(target)}.\n`)

--- a/packages/@vuepress/core/lib/eject.js
+++ b/packages/@vuepress/core/lib/eject.js
@@ -2,6 +2,14 @@
 
 const { path, chalk, fs, logger } = require('@vuepress/shared-utils')
 
+function filter (src) {
+  const exclude = [
+    /theme-default\/node_modules/,
+    /README\.md$/
+  ]
+  return exclude.reduce((prev, ex) => prev && !src.match(ex), true)
+}
+
 module.exports = async (dir) => {
   try {
     require.resolve('@vuepress/theme-default')
@@ -11,6 +19,6 @@ module.exports = async (dir) => {
   }
   const source = require.resolve('@vuepress/theme-default').replace(/index\.js$/, '')
   const target = path.resolve(dir, '.vuepress/theme')
-  await fs.copy(source, target)
+  await fs.copy(source, target, { filter })
   logger.success(`\nCopied default theme into ${chalk.cyan(target)}.\n`)
 }


### PR DESCRIPTION
closes #901 
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

The eject command doesn't work properly currently. This PR fixes the error. More detailed info at the bottom of the PR description.

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of default theme, please provide the **before/after** screenshot: 

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

You have tested in the following browsers: (Providing a detailed version will be better.)

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
- [ ] IE

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature
- [ ] Related documents have been updated
- [ ] Related tests have been updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**

As an `index.js` file was added to the default theme's root directory,

```js
require.resolve('@vuepress/theme-default')
```

returns this file instead of the directory. My added code removes `index.js` at the end of the returned string if present.

Also the theme-default's `node_modules` and `README.md` are being excluded from the eject. Tell me if I should revert this.
