### PR TITLE
Extends the support of absolute paths as theme dirs towards plugins

### DIFF
--- a/packages/@vuepress/core/lib/prepare/loadTheme.js
+++ b/packages/@vuepress/core/lib/prepare/loadTheme.js
@@ -46,7 +46,7 @@ module.exports = async function loadTheme (ctx) {
   let themeName
   let themeShortcut
 
-  if (useLocalTheme) {
+  if (useAbsolutePath) {
     themePath = theme
     logger.tip(`\nApply theme located at ${chalk.gray(themePath)}...`)
   } else if (useLocalTheme) {

--- a/packages/@vuepress/core/lib/prepare/loadTheme.js
+++ b/packages/@vuepress/core/lib/prepare/loadTheme.js
@@ -47,7 +47,7 @@ module.exports = async function loadTheme (ctx) {
   let themeShortcut
 
   if (useAbsolutePath) {
-    themePath = theme
+    themePath = path.resolve(theme)
     logger.tip(`\nApply theme located at ${chalk.gray(themePath)}...`)
   } else if (useLocalTheme) {
     themePath = localThemePath

--- a/packages/@vuepress/core/lib/prepare/loadTheme.js
+++ b/packages/@vuepress/core/lib/prepare/loadTheme.js
@@ -33,9 +33,11 @@ module.exports = async function loadTheme (ctx) {
   const theme = siteConfig.theme || cliOptions.theme
   const themeResolver = getThemeResolver()
 
+  const useAbsolutePath = fs.existsSync(theme)
+
   const localThemePath = path.resolve(vuepressDir, 'theme')
   const useLocalTheme =
-    !fs.existsSync(theme) &&
+    !useAbsolutePath &&
     fs.existsSync(localThemePath) &&
     (fs.readdirSync(localThemePath)).length > 0
 
@@ -45,6 +47,9 @@ module.exports = async function loadTheme (ctx) {
   let themeShortcut
 
   if (useLocalTheme) {
+    themePath = theme
+    logger.tip(`\nApply theme located at ${chalk.gray(themePath)}...`)
+  } else if (useLocalTheme) {
     themePath = localThemePath
     logger.tip(`\nApply theme located at ${chalk.gray(themePath)}...`)
   } else if (isString(theme)) {

--- a/packages/@vuepress/core/lib/prepare/loadTheme.js
+++ b/packages/@vuepress/core/lib/prepare/loadTheme.js
@@ -33,11 +33,13 @@ module.exports = async function loadTheme (ctx) {
   const theme = siteConfig.theme || cliOptions.theme
   const themeResolver = getThemeResolver()
 
-  const useAbsolutePath = fs.existsSync(theme)
+  const absoluteThemePath = path.resolve(theme)
+  const useAbsolutePath =
+    fs.existsSync(absoluteThemePath) &&
+    (fs.readdirSync(absoluteThemePath)).length > 0
 
   const localThemePath = path.resolve(vuepressDir, 'theme')
   const useLocalTheme =
-    !useAbsolutePath &&
     fs.existsSync(localThemePath) &&
     (fs.readdirSync(localThemePath)).length > 0
 
@@ -47,7 +49,7 @@ module.exports = async function loadTheme (ctx) {
   let themeShortcut
 
   if (useAbsolutePath) {
-    themePath = path.resolve(theme)
+    themePath = absoluteThemePath
     logger.tip(`\nApply theme located at ${chalk.gray(themePath)}...`)
   } else if (useLocalTheme) {
     themePath = localThemePath


### PR DESCRIPTION
**Summary**

As discussed in #942, the `loadTheme` documentation (`@vuepress/core/lib/prepare/loadTheme.js`) already mentions support of absolute path as a theme directory (even as top priority for resolving):

```
/**
 * Resolve theme.
 *
 *   Resolving Priority:
 *
 *   1. If the theme was a absolute path and that path exists, respect it
 *      as the theme directory.
 *   2. If 'theme' directory located at vuepressDir exists, respect it as
 *      the theme directory.
 *   3. If 'theme' was a shortcut string, resolve it from deps.
```

Support of this is also already working for layouts, global components and templates (these were especially tested by me and are working in a production environment for us).

However, support of the plugin api is missing as of now. This pull request adds support of this feature for absolute paths, getting all three options to include a theme in line again.

**What kind of change does this PR introduce?** (check at least one)

I am unsure if the source documentation can be seen as a statement of intended functional coverage in this case or not.

- [x] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**The PR fulfills these requirements:**

You have tested in the following browsers: (Providing a detailed version will be better.)

- [x] Chrome
- [x] Firefox
- [ ] Safari
- [x] Edge
- [x] IE

If adding a **new feature**, the PR's description includes:

- [x] A convincing reason for adding this feature
- [ ] Related documents have been updated
- [ ] Related tests have been updated
