### PR TITLE
Fix pages number in the pagination plugin

### DIFF
--- a/packages/@vuepress/plugin-pagination/index.js
+++ b/packages/@vuepress/plugin-pagination/index.js
@@ -1,8 +1,8 @@
 const { path } = require('@vuepress/shared-utils')
 
 function getIntervallers (max, interval) {
-  const count = Math.floor(max / interval)
-  const arr = [...Array(count + 1)]
+  const count = max % interval === 0 ? Math.floor(max / interval) : Math.floor(max / interval) + 1
+  const arr = [...Array(count)]
   return arr.map((v, index) => {
     const start = index * interval
     const end = (index + 1) * interval - 1


### PR DESCRIPTION
**Summary**
This fixes a minor bug where the pagination plugin calculates the wrong number of pages when the pages fit exactly. For example, if you have 20 posts, it shows 3 pages instead of 2.

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of default theme, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

You have tested in the following browsers: (Providing a detailed version will be better.)

- [x] Chrome
- [x] Firefox
- [x] Safari
- [ ] Edge
- [ ] IE

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature
- [ ] Related documents have been updated
- [ ] Related tests have been updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
