### PR TITLE
Fit image into parent block horizontally

### DIFF
--- a/packages/@vuepress/theme-default/components/Home.vue
+++ b/packages/@vuepress/theme-default/components/Home.vue
@@ -79,7 +79,7 @@ export default {
     text-align center
     img
       object-fit: contain
-      width: 100%
+      max-width: 100%
       max-height 280px
       display block
       margin 3rem auto 1.5rem

--- a/packages/@vuepress/theme-default/components/Home.vue
+++ b/packages/@vuepress/theme-default/components/Home.vue
@@ -78,6 +78,8 @@ export default {
   .hero
     text-align center
     img
+      object-fit: contain
+      width: 100%
       max-height 280px
       display block
       margin 3rem auto 1.5rem

--- a/packages/@vuepress/theme-default/components/Home.vue
+++ b/packages/@vuepress/theme-default/components/Home.vue
@@ -78,7 +78,6 @@ export default {
   .hero
     text-align center
     img
-      object-fit: contain
       max-width: 100%
       max-height 280px
       display block


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of default theme, please provide the **before/after** screenshot:

Before:
![before](https://user-images.githubusercontent.com/16743037/47964456-da0d1d00-e053-11e8-8b07-fd45469865b0.png)

After:
![after](https://user-images.githubusercontent.com/16743037/47964455-da0d1d00-e053-11e8-8bd4-e4b2102a1370.png)

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

You have tested in the following browsers: (Providing a detailed version will be better.)

- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [x] Edge
- [ ] IE

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature
- [ ] Related documents have been updated
- [ ] Related tests have been updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**

Wide `.hero > img` image doesn't fit into `.hero` horizontally.

Widescreen view isn't changed:
![desktop](https://user-images.githubusercontent.com/16743037/47964671-b26b8400-e056-11e8-8f9b-5ae61beb8466.png)