### PR TITLE
The link to Custom Theme leads to 404

### DIFF
--- a/packages/docs/docs/guide/basic-config.md
+++ b/packages/docs/docs/guide/basic-config.md
@@ -34,7 +34,7 @@ You can also use YAML (`.vuepress/config.yml`) or TOML (`.vuepress/config.toml`)
 
 A VuePress theme is responsible for all the layout and interactivity details of your site. VuePress ships with a default theme (you are looking at it right now) which is designed for technical documentation. It exposes a number of options that allow you to customize the navbar, sidebar and homepage, etc. For details, check out the [Default Theme Config](../theme/default-theme-config.md) page.
 
-If you wish to develop a custom theme, see [Custom Themes](custom-themes.md).
+If you wish to develop a custom theme, see [Writing a theme](../theme/writing-a-theme.md).
 
 ## App Level Enhancements
 


### PR DESCRIPTION
**Summary**

The page 'Custom Theme' looks have gone. The link should lead visitors to the page ['Writing a theme'](https://vuepress.vuejs.org/theme/writing-a-theme.html).

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [x] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of default theme, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

You have tested in the following browsers: (Providing a detailed version will be better.)

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
- [ ] IE

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature
- [ ] Related documents have been updated
- [ ] Related tests have been updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
