### PR TITLE
🐛 Fix medium-zoom not updating on component update

### DIFF
--- a/packages/@vuepress/plugin-medium-zoom/mixin.js
+++ b/packages/@vuepress/plugin-medium-zoom/mixin.js
@@ -4,9 +4,22 @@ import './style.css'
 import zoom from 'medium-zoom'
 
 export default {
+  data: () => ({ zoom: null }),
+
   mounted () {
+    const self = this
     setTimeout(() => {
-      zoom(SELECTOR)
+      self.zoom = zoom(SELECTOR)
+    }, 1000)
+  },
+
+  updated () {
+    const self = this
+    setTimeout(() => {
+      if (self.zoom) {
+        self.zoom.detach()
+        self.zoom.attach(SELECTOR)
+      }
     }, 1000)
   }
 }

--- a/packages/@vuepress/plugin-medium-zoom/mixin.js
+++ b/packages/@vuepress/plugin-medium-zoom/mixin.js
@@ -7,19 +7,21 @@ export default {
   data: () => ({ zoom: null }),
 
   mounted () {
-    const self = this
-    setTimeout(() => {
-      self.zoom = zoom(SELECTOR)
-    }, 1000)
+    this.updateZoom()
   },
 
   updated () {
-    const self = this
-    setTimeout(() => {
-      if (self.zoom) {
-        self.zoom.detach()
-      }
-      self.zoom = zoom(SELECTOR)
-    }, 1000)
+    this.updateZoom()
+  },
+
+  methods: {
+    updateZoom () {
+      setTimeout(() => {
+        if (this.zoom) {
+          this.zoom.detach()
+        }
+        this.zoom = zoom(SELECTOR)
+      }, 1000)
+    }
   }
 }

--- a/packages/@vuepress/plugin-medium-zoom/mixin.js
+++ b/packages/@vuepress/plugin-medium-zoom/mixin.js
@@ -18,8 +18,8 @@ export default {
     setTimeout(() => {
       if (self.zoom) {
         self.zoom.detach()
-        self.zoom.attach(SELECTOR)
       }
+      self.zoom = zoom(SELECTOR)
     }, 1000)
   }
 }

--- a/packages/@vuepress/plugin-medium-zoom/package.json
+++ b/packages/@vuepress/plugin-medium-zoom/package.json
@@ -17,7 +17,7 @@
     "generator"
   ],
   "dependencies": {
-    "medium-zoom": "^1.0.2"
+    "medium-zoom": "^0.4.0"
   },
   "author": "ULIVZ <chl814@foxmail.com>",
   "license": "MIT",

--- a/packages/@vuepress/plugin-medium-zoom/package.json
+++ b/packages/@vuepress/plugin-medium-zoom/package.json
@@ -17,7 +17,7 @@
     "generator"
   ],
   "dependencies": {
-    "medium-zoom": "^0.4.0"
+    "medium-zoom": "^1.0.2"
   },
   "author": "ULIVZ <chl814@foxmail.com>",
   "license": "MIT",


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

medium-zoom doesn't get attached to newly loaded images when the user navigates to other routes within a vuepress project. The problem is that medium-zoom gets attached to currently available images when the LayoutDistributor is mounted, but not when it's updated (e.g. when the user navigates to a new route).

My fix detaches all images from medium-zoom when the LayoutDistributor updates (as images could have been removed from the DOM) and attaches all current images in the DOM which match the provided selector.

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of default theme, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

You have tested in the following browsers: (Providing a detailed version will be better.)

- [x] Chrome
- [x] Firefox
- [x] Safari
- [ ] Edge
- [ ] IE

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature
- [ ] Related documents have been updated
- [ ] Related tests have been updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**

I wanted to upgrade to medium-zoom v1.0.2 but the `vuepress build` command threw an error that the window object isn't defined. I don't understand why that happens as the window object is also used in v0.4.0. The error appears when medium-zoom tries to access `window.Promise`.