### PR TITLE
feat($plugin-blog): Allow the permalink for blog posts to be configured.

### DIFF
--- a/packages/@vuepress/plugin-blog/index.js
+++ b/packages/@vuepress/plugin-blog/index.js
@@ -5,7 +5,8 @@ module.exports = (options, ctx) => {
   const {
     pageEnhancers = [],
     categoryIndexPageUrl = '/category/',
-    tagIndexPageUrl = '/tag/'
+    tagIndexPageUrl = '/tag/',
+    permalink = '/:year/:month/:day/:slug'
   } = options
 
   const isLayoutExists = name => layoutComponentMap[name] !== undefined
@@ -42,7 +43,7 @@ module.exports = (options, ctx) => {
       when: ({ regularPath }) => regularPath.startsWith('/_posts/'),
       frontmatter: {
         layout: getLayout('Post', 'Page'),
-        permalink: '/:year/:month/:day/:slug'
+        permalink: permalink
       },
       data: { type: 'post' }
     },

--- a/packages/docs/docs/plugin/official/plugin-blog.md
+++ b/packages/docs/docs/plugin/official/plugin-blog.md
@@ -32,3 +32,10 @@ module.exports = {
 
 - Type: `string`
 - Default: `/tag/`
+
+### permalink
+
+- Type: `string`
+- Default: `/:year/:month/:day/:slug`
+
+Configures the permalink generated for blog posts. See [Permalinks](/guide/permalinks.html#template-variables) for a list of valid variables.


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

The VuePress blog plugin provides an opinionated default for the URL of blog posts. As of v1.0.0-alpha.20 changing the permalink URL of blog posts is only possible via passing a custom "pageEnhancer" to `plugin-blog`. That pageEnhancer basically overwrites `page.frontmatter.permalink`. This workaround `config.js` looks similar to:

```javascript
module.exports = {
  plugins: {
    '@vuepress/blog': {
      pageEnhancers: [{
        when: page => page.type === 'post',
        frontmatter: {permalink: '/custom/permalink/:slug'}
      }]
    }
}
```

To simplify the solution, this PR adds a new configuration option `permalink` to the blog plugin that allows to configure the permalink URL for blog posts. The new configuration option uses the same default as previously:

```javascript
module.exports = {
  plugins: {
    '@vuepress/blog': {
      permalink: '/custom/permalink/:slug'
    }
}
```


The corresponding plugin documentation in English language was updated.

`plugin-blog` does not seem to have any tests that can be updated (please correct me, if I am wrong).

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [x] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

You have tested in the following browsers: (Providing a detailed version will be better.)

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
- [ ] IE

If adding a **new feature**, the PR's description includes:

- [x] A convincing reason for adding this feature
- [x] Related documents have been updated
- [ ] Related tests have been updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
