### PR TITLE
feat($plugin-blog): add postsDir option

### DIFF
--- a/packages/@vuepress/plugin-blog/index.js
+++ b/packages/@vuepress/plugin-blog/index.js
@@ -4,6 +4,7 @@ module.exports = (options, ctx) => {
   const { layoutComponentMap } = ctx
   const {
     pageEnhancers = [],
+    postsDir = '_posts',
     categoryIndexPageUrl = '/category/',
     tagIndexPageUrl = '/tag/',
     permalink = '/:year/:month/:day/:slug'
@@ -40,7 +41,7 @@ module.exports = (options, ctx) => {
       frontmatter: { layout: getLayout('Layout') }
     },
     {
-      when: ({ regularPath }) => regularPath.startsWith('/_posts/'),
+      when: ({ regularPath }) => regularPath.startsWith(`/${postsDir}/`),
       frontmatter: {
         layout: getLayout('Post', 'Page'),
         permalink: permalink

--- a/packages/docs/docs/plugin/official/plugin-blog.md
+++ b/packages/docs/docs/plugin/official/plugin-blog.md
@@ -23,6 +23,11 @@ module.exports = {
 
 ## Options
 
+### postsDir
+
+- Type: `string`
+- Default: `_posts`
+
 ### categoryIndexPageUrl
 
 - Type: `string`

--- a/packages/docs/docs/zh/plugin/official/plugin-blog.md
+++ b/packages/docs/docs/zh/plugin/official/plugin-blog.md
@@ -23,6 +23,11 @@ module.exports = {
 
 ## 选项
 
+### postsDir
+
+- 类型: `string`
+- 默认值: `_posts`
+
 ### categoryIndexPageUrl
 
 - 类型: `string`
@@ -33,3 +38,9 @@ module.exports = {
 - 类型: `string`
 - 默认值: `/tag/`
 
+### permalink
+
+- 类型: `string`
+- 默认值: `/:year/:month/:day/:slug`
+
+为博客文章设置永久链接。详情参考 [Permalinks](/zh/guide/permalinks.html#模板变量)。


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of default theme, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

You have tested in the following browsers: (Providing a detailed version will be better.)

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
- [ ] IE

If adding a **new feature**, the PR's description includes:

- [x] A convincing reason for adding this feature
- [x] Related documents have been updated
- [ ] Related tests have been updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**

Current blog plugin use `_posts` as the posts directory and could not be changed (no docs about that, too). Make this option configurable would be better.