### PR TITLE
Adds option for specifying the top offset

### DIFF
--- a/packages/@vuepress/plugin-active-header-links/index.js
+++ b/packages/@vuepress/plugin-active-header-links/index.js
@@ -4,6 +4,7 @@ module.exports = (options) => ({
   clientRootMixin: path.resolve(__dirname, 'mixin.js'),
   define: {
     AHL_SIDEBAR_LINK_SELECTOR: options.sidebarLinkSelector || '.sidebar-link',
-    AHL_HEADER_ANCHOR_SELECTOR: options.headerAnchorSelector || '.header-anchor'
+    AHL_HEADER_ANCHOR_SELECTOR: options.headerAnchorSelector || '.header-anchor',
+    AHL_TOP_OFFSET: options.headerTopOffset || 90
   }
 })

--- a/packages/@vuepress/plugin-active-header-links/mixin.js
+++ b/packages/@vuepress/plugin-active-header-links/mixin.js
@@ -1,4 +1,4 @@
-/* global AHL_SIDEBAR_LINK_SELECTOR, AHL_HEADER_ANCHOR_SELECTOR */
+/* global AHL_SIDEBAR_LINK_SELECTOR, AHL_HEADER_ANCHOR_SELECTOR, AHL_TOP_OFFSET */
 
 import throttle from 'lodash.throttle'
 
@@ -35,8 +35,8 @@ function getAnchors () {
       return {
         el,
         hash: decodeURIComponent(el.hash),
-        top: el.getBoundingClientRect().top - 90
-        /* 90 is to Subtract height of navbar & anchor's padding top */
+        top: el.getBoundingClientRect().top - AHL_TOP_OFFSET
+        /* AHL_TOP_OFFSET is to Subtract height of navbar & anchor's padding top */
       }
     })
 }

--- a/packages/docs/docs/plugin/official/plugin-active-header-links.md
+++ b/packages/docs/docs/plugin/official/plugin-active-header-links.md
@@ -18,11 +18,20 @@ yarn add -D @vuepress/plugin-active-header-links
 
 ```javascript
 module.exports = {
-  plugins: ['@vuepress/active-header-links'] 
+  plugins: ['@vuepress/active-header-links']
 }
 ```
 
 ## Options
+```javascript
+module.exports = {
+  plugins: ['@vuepress/active-header-links', {
+    sidebarLinkSelector: '.sidebar-link',
+    headerAnchorSelector: '.header-anchor',
+    headerTopOffset: 120
+  }]
+}
+```
 
 ### sidebarLinkSelector
 
@@ -32,5 +41,10 @@ module.exports = {
 ### headerAnchorSelector
 
 - Type: `string`
-- Default: `.header-anchor'`
+- Default: `.header-anchor`
+
+### headerTopOffset
+
+- Type: `integer`
+- Default: `90`
 

--- a/packages/docs/docs/plugin/official/plugin-active-header-links.md
+++ b/packages/docs/docs/plugin/official/plugin-active-header-links.md
@@ -22,7 +22,7 @@ module.exports = {
 }
 ```
 
-## Options
+### Passing Options
 ```javascript
 module.exports = {
   plugins: ['@vuepress/active-header-links', {
@@ -32,6 +32,8 @@ module.exports = {
   }]
 }
 ```
+
+## Options
 
 ### sidebarLinkSelector
 
@@ -44,6 +46,7 @@ module.exports = {
 - Default: `.header-anchor`
 
 ### headerTopOffset
+The number of pixels that you want the header to be from the top of the page before updating the url hash switch to that header.
 
 - Type: `integer`
 - Default: `90`


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**
Allowing the addition of a theme that is not the default VuePress theme, the header is not always going to be 90.  This PR allows you to define the option of the top offset from the configuration of the plugin.


**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [x] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of default theme, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

You have tested in the following browsers: (Providing a detailed version will be better.)

- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
- [ ] IE

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature
- [ ] Related documents have been updated
- [ ] Related tests have been updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**

This also includes documentation update on how to specify options for this plugin
