### PR TITLE
Empty build output directory instead of remove

### DIFF
--- a/packages/@vuepress/core/lib/build.js
+++ b/packages/@vuepress/core/lib/build.js
@@ -23,7 +23,7 @@ module.exports = async function build (sourceDir, cliOptions = {}) {
     return console.error(logger.error(chalk.red('Unexpected option: outDir cannot be set to the current working directory.\n'), false))
   }
 
-  await fs.remove(outDir)
+  await fs.emptyDir(outDir)
   logger.debug('Dist directory: ' + chalk.gray(outDir))
 
   let clientConfig = createClientConfig(ctx, cliOptions).toConfig()


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [x] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of default theme, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

This PR simply changes `fs.remove` during build/`build.js` to `fs.emptyDir`. This arose due to a semi-funky build system in which we are building the documentation via Docker container into a Docker volume which is also attached to an NGINX container which has the `.vuepress/dist` folder mounted as a Volume and served via NGINX. `fs.remove` attempts to unlink the `dist` folder, causing a build failure due to the NGINX mount. `emptyDir` simply empties the directory and does not delete it, and I couldn't obviously see a dependency on totally removing the `.vuepress/dist` folder.

Unfortunately there was a significant amount of test failures, but none that looked suspiciously due to this change:

```
Test Suites: 27 failed, 3 passed, 30 total
Tests:       4 failed, 8 passed, 12 total
Snapshots:   0 total
Time:        6.872s
Ran all test suites.
```

Many due to:
```
 FAIL  packages/@vuepress/shared-utils/__tests__/fileToPath.spec.js
  ● Test suite failed to run

    TypeError: programPath.hub.addHelper is not a function

      at wrapInterop (node_modules/@babel/plugin-transform-modules-commonjs/node_modules/@babel/helper-module-transforms/lib/index.js:165:45)
      at PluginPass.exit (node_modules/@babel/plugin-transform-modules-commonjs/lib/index.js:174:70)
      at newFn (node_modules/@babel/traverse/lib/visitors.js:193:21)
      at NodePath._call (node_modules/@babel/traverse/lib/path/context.js:53:20)
      at NodePath.call (node_modules/@babel/traverse/lib/path/context.js:40:17)
      at NodePath.visit (node_modules/@babel/traverse/lib/path/context.js:97:8)
      at TraversalContext.visitQueue (node_modules/@babel/traverse/lib/context.js:118:16)
      at TraversalContext.visitSingle (node_modules/@babel/traverse/lib/context.js:90:19)
      at TraversalContext.visit (node_modules/@babel/traverse/lib/context.js:146:19)
      at Function.traverse.node (node_modules/@babel/traverse/lib/index.js:94:17)
```

Built and run in Docker:
```Dockerfile
FROM node:alpine
COPY . /data/
WORKDIR /data/
ENTRYPOINT [ "sh" ]
CMD [ "test.sh" ]
```
```sh
#!/usr/bin/env sh
yarn
yarn test
yarn dev
```

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

You have tested in the following browsers: (Providing a detailed version will be better.)

- [ ] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge
- [ ] IE

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature
- [ ] Related documents have been updated
- [ ] Related tests have been updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
