### PR TITLE
handle SSR when linksWrapMaxWidth is null

### DIFF
--- a/packages/@vuepress/theme-default/components/Navbar.vue
+++ b/packages/@vuepress/theme-default/components/Navbar.vue
@@ -22,9 +22,9 @@
 
     <div
       class="links"
-      :style="{
+      :style="linksWrapMaxWidth != null ? {
         'max-width': linksWrapMaxWidth + 'px'
-      }"
+      } : {}"
     >
       <AlgoliaSearchBox
         v-if="isAlgoliaSearch"

--- a/packages/@vuepress/theme-default/components/Navbar.vue
+++ b/packages/@vuepress/theme-default/components/Navbar.vue
@@ -22,7 +22,7 @@
 
     <div
       class="links"
-      :style="linksWrapMaxWidth != null ? {
+      :style="linksWrapMaxWidth !== null ? {
         'max-width': linksWrapMaxWidth + 'px'
       } : {}"
     >

--- a/packages/@vuepress/theme-default/components/Navbar.vue
+++ b/packages/@vuepress/theme-default/components/Navbar.vue
@@ -22,7 +22,7 @@
 
     <div
       class="links"
-      :style="linksWrapMaxWidth !== null ? {
+      :style="linksWrapMaxWidth ? {
         'max-width': linksWrapMaxWidth + 'px'
       } : {}"
     >


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of default theme, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

You have tested in the following browsers: (Providing a detailed version will be better.)

- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
- [ ] IE

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature
- [ ] Related documents have been updated
- [ ] Related tests have been updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**

Currently the the template renders the following invalid CSS with maxwidth "null" in the server side pre-rendered HTML page

````<div class="links" style="max-width:nullpx;">```` 

This change avoid rendering this CSS snippet when `linksWrapMaxWidth` is null. Once the JavaScript is executed on the client side the CSS is properly replaced with the calculated maxwidth.