### PR TITLE
fix #1048: use slotKey prop for markdown slots

### DIFF
--- a/packages/@vuepress/core/lib/app/components/Content.js
+++ b/packages/@vuepress/core/lib/app/components/Content.js
@@ -19,7 +19,7 @@ export default {
         class: [data.class, data.staticClass],
         style: data.style,
         props: {
-          slotKey: props.slot || 'default'
+          slotKey: props.slotKey || 'default'
         }
       })
     }

--- a/packages/docs/docs/guide/markdown-slot.md
+++ b/packages/docs/docs/guide/markdown-slot.md
@@ -17,7 +17,7 @@ Markdown Slot is to solve this kind of problem.
 You can define a named markdown slot through the following markdown syntax:
 
 ``` md
-::: slot [$name]
+::: slot name
 
 :::
 ```
@@ -25,7 +25,7 @@ You can define a named markdown slot through the following markdown syntax:
 Use the `Content` component to use the slot in the layout component:
 
 ``` vue
-<Content slot="$name"/> 
+<Content slot-key="name"/>
 ```
 
 ## Default Slot Content


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

Fix content component to use `slotKey` instead of unavailable `slot` prop. Clean up readme with consistent example.

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**The PR fulfills these requirements:**

- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

You have tested in the following browsers: (Providing a detailed version will be better.)

- [x] Chrome 70.0.3538.110
- [ ] Firefox
- [x] Safari 12.0
- [ ] Edge
- [ ] IE

**Other information:**
Fixes #1048 