### PR TITLE
fix($cli): bump CAC version

### DIFF
--- a/packages/@vuepress/cli/package.json
+++ b/packages/@vuepress/cli/package.json
@@ -28,7 +28,7 @@
     "url": "https://github.com/vuejs/vuepress/issues"
   },
   "dependencies": {
-    "cac": "^6.3.3",
+    "cac": "^6.3.6",
     "chalk": "^2.3.2",
     "semver": "^5.5.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1681,9 +1681,9 @@ byline@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/byline/-/byline-5.0.0.tgz#741c5216468eadc457b03410118ad77de8c1ddb1"
 
-cac@^6.3.3:
-  version "6.3.3"
-  resolved "https://registry.yarnpkg.com/cac/-/cac-6.3.3.tgz#01e56f50068bd1be326b1612950d77d31112400d"
+cac@^6.3.6:
+  version "6.3.9"
+  resolved "https://registry.yarnpkg.com/cac/-/cac-6.3.9.tgz#0cdf3f2d3a7d3fb71ab89c476c73e472084859a2"
 
 cacache@^10.0.4:
   version "10.0.4"


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [x] Build-related changes
- [ ] Other, please describe:

If changing the UI of default theme, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

You have tested in the following browsers: (Providing a detailed version will be better.)

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
- [ ] IE

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature
- [ ] Related documents have been updated
- [ ] Related tests have been updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**

Bumping cac to at least v6.3.6 to include the fix for https://github.com/cacjs/cac/issues/34

Since the introduction of cac to vuepress, the command line option `--cache [cache]` has not worked correctly:
* `--cache`: `cliOptions.cache === true`
* `--no-cache`: `cliOptions.cache === false`
* `--cache /path/to/some/dir`: `cliOptions.cache === true`, `targetDir === "/path/to/some/dir"`

Since `--no-cache` is defined, `--cache`/`--no-cache` can only be a boolean, and so any argument that you attempt to pass to `--cache` is interpreted as an individual argument, and in this case becomes the `targetDir`.

Using at least cac v6.3.6 will correct this behaviour to instead accept the argument passed to `--cache` into `cliOptions.cache` as expected:
* `--cache`: `cliOptions.cache === true`
* `--no-cache`: `cliOptions.cache === false`
* `--cache /path/to/some/dir`: `cliOptions.cache === "/path/to/some/dir"`