### PR TITLE
Allowing config option to set which headers to extract

### DIFF
--- a/packages/@vuepress/core/lib/prepare/AppContext.js
+++ b/packages/@vuepress/core/lib/prepare/AppContext.js
@@ -292,6 +292,7 @@ module.exports = class AppContext {
 
   async addPage (options) {
     options.permalinkPattern = this.siteConfig.permalink
+    options.siteConfig = this.siteConfig
     const page = new Page(options, this)
     await page.process({
       markdown: this.markdown,

--- a/packages/@vuepress/core/lib/prepare/Page.js
+++ b/packages/@vuepress/core/lib/prepare/Page.js
@@ -45,7 +45,8 @@ module.exports = class Page {
     relative,
     permalink,
     frontmatter = {},
-    permalinkPattern
+    permalinkPattern,
+    siteConfig
   }, context) {
     this.title = title
     this._meta = meta
@@ -54,6 +55,7 @@ module.exports = class Page {
     this._permalink = permalink
     this.frontmatter = frontmatter
     this._permalinkPattern = permalinkPattern
+    this._siteConfig = siteConfig
     this._context = context
 
     if (relative) {
@@ -108,9 +110,13 @@ module.exports = class Page {
         }
 
         // headers
+        this.headersToExtract = ['h2', 'h3']
+        if (this._siteConfig.markdown && this._siteConfig.markdown.extractHeaders) {
+          this.headersToExtract = this._siteConfig.markdown.extractHeaders
+        }
         const headers = extractHeaders(
           this._strippedContent,
-          ['h2', 'h3'],
+          this.headersToExtract,
           markdown
         )
         if (headers.length) {

--- a/packages/@vuepress/core/lib/webpack/createBaseConfig.js
+++ b/packages/@vuepress/core/lib/webpack/createBaseConfig.js
@@ -33,6 +33,7 @@ module.exports = function createBaseConfig ({
   const inlineLimit = 10000
 
   const config = new Config()
+  const markdownConfig = siteConfig.markdown
 
   config
     .mode(isProd && !env.isDebug ? 'production' : 'development')
@@ -116,7 +117,7 @@ module.exports = function createBaseConfig ({
   mdRule
     .use('markdown-loader')
       .loader(require.resolve('@vuepress/markdown-loader'))
-      .options({ sourceDir, markdown, siteConfig })
+      .options({ sourceDir, markdown, markdownConfig })
 
   config.module
     .rule('pug')

--- a/packages/@vuepress/core/lib/webpack/createBaseConfig.js
+++ b/packages/@vuepress/core/lib/webpack/createBaseConfig.js
@@ -116,7 +116,7 @@ module.exports = function createBaseConfig ({
   mdRule
     .use('markdown-loader')
       .loader(require.resolve('@vuepress/markdown-loader'))
-      .options({ sourceDir, markdown })
+      .options({ sourceDir, markdown, siteConfig })
 
   config.module
     .rule('pug')

--- a/packages/@vuepress/markdown-loader/index.js
+++ b/packages/@vuepress/markdown-loader/index.js
@@ -22,7 +22,7 @@ module.exports = function (src) {
   const isServer = this.target === 'node'
   const options = getOptions(this)
   const { sourceDir } = options
-  const { siteConfig } = options
+  const { markdownConfig } = options
   let { markdown } = options
   if (!markdown) {
     markdown = md()
@@ -44,8 +44,8 @@ module.exports = function (src) {
   if (!isProd && !isServer) {
     const inferredTitle = inferTitle(frontmatter.data, frontmatter.content)
     let headersToExtract = ['h2', 'h3']
-    if (siteConfig.markdown && siteConfig.markdown.extractHeaders) {
-      headersToExtract = siteConfig.markdown.extractHeaders
+    if (markdownConfig && markdownConfig.extractHeaders) {
+      headersToExtract = markdownConfig.extractHeaders
     }
     const headers = extractHeaders(content, headersToExtract, markdown)
     delete frontmatter.content

--- a/packages/@vuepress/markdown-loader/index.js
+++ b/packages/@vuepress/markdown-loader/index.js
@@ -22,6 +22,7 @@ module.exports = function (src) {
   const isServer = this.target === 'node'
   const options = getOptions(this)
   const { sourceDir } = options
+  const { siteConfig } = options
   let { markdown } = options
   if (!markdown) {
     markdown = md()
@@ -42,7 +43,11 @@ module.exports = function (src) {
 
   if (!isProd && !isServer) {
     const inferredTitle = inferTitle(frontmatter.data, frontmatter.content)
-    const headers = extractHeaders(content, ['h2', 'h3'], markdown)
+    let headersToExtract = ['h2', 'h3']
+    if (siteConfig.markdown && siteConfig.markdown.extractHeaders) {
+      headersToExtract = siteConfig.markdown.extractHeaders
+    }
+    const headers = extractHeaders(content, headersToExtract, markdown)
     delete frontmatter.content
 
     // diff frontmatter and title, since they are not going to be part of the

--- a/packages/docs/docs/theme/default-theme-config.md
+++ b/packages/docs/docs/theme/default-theme-config.md
@@ -154,6 +154,17 @@ module.exports = {
 }
 ```
 
+### Extract Headers
+ While preparing the page, headers are extracted from the markdown file and stored in `this.$page.headers`. By default, VuePress will extract `h2` and `h3` elements for you.
+ You can override the headers it pulls out in your `markdown` options.
+ ``` js
+module.exports = {
+  markdown: {
+    extractHeaders: [ 'h2', 'h3', 'h4' ]
+  }
+}
+```
+
 ### Active Header Links
 
 By default, the nested header links and the hash in the URL are updated as the user scrolls to view the different sections of the page. This behavior can be disabled with the following theme config:


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**
This PR resolves #984 
This PR replaces #1004 

Currently the header parsing is hard coded to `['h2', 'h3']`. This code changes that to give the ability to configure this in the `themeOptions` config.


**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [x] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of default theme, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

You have tested in the following browsers: (Providing a detailed version will be better.)

- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
- [ ] IE

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature
- [ ] Related documents have been updated
- [ ] Related tests have been updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
