### PR TITLE
Align param source priority for theme with other params (cliOptions > siteConfig)

### DIFF
--- a/packages/@vuepress/core/lib/prepare/loadTheme.js
+++ b/packages/@vuepress/core/lib/prepare/loadTheme.js
@@ -30,7 +30,7 @@ const {
 
 module.exports = async function loadTheme (ctx) {
   const { siteConfig, cliOptions, sourceDir, vuepressDir, pluginAPI } = ctx
-  const theme = siteConfig.theme || cliOptions.theme
+  const theme = cliOptions.theme || siteConfig.theme
   const themeResolver = getThemeResolver()
 
   const localThemePath = path.resolve(vuepressDir, 'theme')


### PR DESCRIPTION
**Summary**
For all other parameters cliOptions has higher priority than siteOptions, 
for theme it is the opposite.
When command line arguments are not of highest priority here, 
Some strange behavior might come up for usages.

```
packages/@vuepress/core/lib/prepare/CacheLoader.js
20:  let cache = cliOptions.cache || siteConfig.cache || defaultCacheDirectory

packages/@vuepress/core/lib/prepare/AppContext.js
51:    const { tempPath, writeTemp } = createTemp(cliOptions.temp)
77:    const rawOutDir = this.cliOptions.dest || this.siteConfig.dest
168:    this.pluginAPI.useByPluginsConfig(this.cliOptions.plugins)

packages/@vuepress/core/lib/prepare/loadTheme.js
33:  const theme = siteConfig.theme || cliOptions.theme

packages/@vuepress/core/lib/dev.js
79:  const port = await resolvePort(cliOptions.port || ctx.siteConfig.port)
80:  const { host, displayHost } = await resolveHost(cliOptions.host || ctx.siteConfig.host)
124:    open: cliOptions.open,

```

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [x] Build-related changes
- [ ] Other, please describe:

If changing the UI of default theme, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)
- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

You have tested in the following browsers: (Providing a detailed version will be better.)

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
- [ ] IE

If adding a **new feature**, the PR's description includes:

- [x] A convincing reason for adding this feature
- [ ] Related documents have been updated
- [ ] Related tests have been updated
