### PR TITLE
feat(blog) add component as layout option for Tags/Categories

### DIFF
--- a/packages/@vuepress/plugin-blog/index.js
+++ b/packages/@vuepress/plugin-blog/index.js
@@ -2,6 +2,7 @@ const { path, datatypes: { isString }} = require('@vuepress/shared-utils')
 
 module.exports = (options, ctx) => {
   const { layoutComponentMap } = ctx
+  const componentMap = {}
   const {
     pageEnhancers = [],
     postsDir = '_posts',
@@ -11,8 +12,13 @@ module.exports = (options, ctx) => {
   } = options
 
   const isLayoutExists = name => layoutComponentMap[name] !== undefined
-  const getLayout = (name, fallback) => isLayoutExists(name) ? name : fallback
+  const componentExists = name => componentMap[name] !== undefined
+  const getLayout = (name, fallback) => isLayoutExists(name) || componentExists(name)  ? name : fallback
   const isDirectChild = regularPath => path.parse(regularPath).dir === '/'
+
+  fs.readdirSync(`${sourceDir}/.vuepress/components/`).forEach(file => {
+    componentMap[file.split(".")[0]] = file
+  })
 
   const enhancers = [
     {

--- a/packages/@vuepress/plugin-blog/index.js
+++ b/packages/@vuepress/plugin-blog/index.js
@@ -1,7 +1,8 @@
+const fs = require("fs")
 const { path, datatypes: { isString }} = require('@vuepress/shared-utils')
 
 module.exports = (options, ctx) => {
-  const { layoutComponentMap } = ctx
+  const { layoutComponentMap, sourceDir } = ctx
   const componentMap = {}
   const {
     pageEnhancers = [],


### PR DESCRIPTION
**Summary**
It seems that typically you'd have custom theme for the blog plugin but it would be nice to define a layout component from the `.vuepress/components` directory similar to how you can specify `layout` in frontmatter normally.

This allows the plugin to use tags and categories without the need for a custom theme.

Example usage here: https://github.com/darrenjennings/guuu.io/blob/feat/service-worker/docs/.vuepress/components/Tag.vue where I'm using the default theme and creating custom components that hook into and extend `@vuepress/theme-default/layouts/Layout`

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

You have tested in the following browsers: (Providing a detailed version will be better.)

- [x] Chrome (although this was a server side change.)
- [ ] Firefox
- [ ] Safari
- [ ] Edge
- [ ] IE

If adding a **new feature**, the PR's description includes:

- [x] A convincing reason for adding this feature
- [ ] Related documents have been updated
- [ ] Related tests have been updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**

I am new to this codebase so I am unsure this was the best way to tackle this issue.
