### PR TITLE
fix($theme-default): front matter prev / next links

### DIFF
--- a/packages/@vuepress/theme-default/util/index.js
+++ b/packages/@vuepress/theme-default/util/index.js
@@ -53,7 +53,18 @@ export function isActive (route, path) {
   return routePath === pagePath
 }
 
+function normalizedPagesMap (pages) {
+  return pages.reduce((map, page) => {
+    map[normalize(page.regularPath)] = page
+    return map
+  }, {})
+}
+
 export function resolvePage (pages, rawPath, base) {
+  return resolvePageByMap(normalizedPagesMap(pages), rawPath, base)
+}
+
+function resolvePageByMap (pages, rawPath, base) {
   if (base) {
     rawPath = resolvePath(rawPath, base)
   }
@@ -126,16 +137,12 @@ export function resolveSidebarItems (page, regularPath, site, localePath) {
   }
 
   const sidebarConfig = localeConfig.sidebar || themeConfig.sidebar
-  const normalizedPagesMap = pages.reduce((map, page) => {
-    map[normalize(page.regularPath)] = page
-    return map
-  }, {})
   if (!sidebarConfig) {
     return []
   } else {
     const { base, config } = resolveMatchingConfig(regularPath, sidebarConfig)
     return config
-      ? config.map(item => resolveItem(item, normalizedPagesMap, base))
+      ? config.map(item => resolveItem(item, normalizedPagesMap(pages), base))
       : []
   }
 }
@@ -211,9 +218,9 @@ function ensureEndingSlash (path) {
 
 function resolveItem (item, pages, base, isNested) {
   if (typeof item === 'string') {
-    return resolvePage(pages, item, base)
+    return resolvePageByMap(pages, item, base)
   } else if (Array.isArray(item)) {
-    return Object.assign(resolvePage(pages, item[0], base), {
+    return Object.assign(resolvePageByMap(pages, item[0], base), {
       title: item[1]
     })
   } else {


### PR DESCRIPTION
fixes bug introduced with #1068.

<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of default theme, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

You have tested in the following browsers: (Providing a detailed version will be better.)

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
- [ ] IE

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature
- [ ] Related documents have been updated
- [ ] Related tests have been updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**

Fixes bug in 1.0.0-alpha.30 where adding this front matter to top of page causes build to fail (assuming using default theme and the file /tutorial/README.md exists
```
---
next: ./tutorial/
---
```
