### PR TITLE
fix: LRU does not use the "new" operator

### DIFF
--- a/packages/@vuepress/core/lib/internal-plugins/frontmatterBlock/loader.js
+++ b/packages/@vuepress/core/lib/internal-plugins/frontmatterBlock/loader.js
@@ -1,7 +1,7 @@
 const { parseVueFrontmatter: { parseStrippedFrontmatter }} = require('@vuepress/shared-utils')
 const { frontmatterEmitter } = require('@vuepress/markdown-loader')
 const LRU = require('lru-cache')
-const cache = LRU({ max: 1000 })
+const cache = new LRU({ max: 1000 })
 
 module.exports = function (source, map) {
   const isProd = process.env.NODE_ENV === 'production'

--- a/packages/@vuepress/core/package.json
+++ b/packages/@vuepress/core/package.json
@@ -51,7 +51,7 @@
     "koa-mount": "^3.0.0",
     "koa-range": "^0.3.0",
     "koa-static": "^4.0.2",
-    "lru-cache": "^4.1.2",
+    "lru-cache": "^5.1.1",
     "mini-css-extract-plugin": "0.4.4",
     "optimize-css-assets-webpack-plugin": "^4.0.0",
     "portfinder": "^1.0.13",

--- a/packages/@vuepress/markdown-loader/index.js
+++ b/packages/@vuepress/markdown-loader/index.js
@@ -10,8 +10,8 @@ const { fs, path, hash, parseFrontmatter, inferTitle, extractHeaders } = require
 const LRU = require('lru-cache')
 const md = require('@vuepress/markdown')
 
-const cache = LRU({ max: 1000 })
-const devCache = LRU({ max: 1000 })
+const cache = new LRU({ max: 1000 })
+const devCache = new LRU({ max: 1000 })
 
 /**
  * Expose markdown loader.

--- a/packages/@vuepress/markdown/__tests__/util.js
+++ b/packages/@vuepress/markdown/__tests__/util.js
@@ -2,7 +2,7 @@ import fs from 'fs-extra'
 import LRU from 'lru-cache'
 import path from 'path'
 
-const cache = LRU({ max: 1000 })
+const cache = new LRU({ max: 1000 })
 
 export function Md () {
   return require('markdown-it')()

--- a/packages/@vuepress/shared-utils/src/extractHeaders.ts
+++ b/packages/@vuepress/shared-utils/src/extractHeaders.ts
@@ -10,7 +10,7 @@ import deeplyParseHeaders from './deeplyParseHeaders'
  * @returns {array}
  */
 
-const cache = LRU({ max: 1000 })
+const cache = new LRU({ max: 1000 })
 
 export = function (content: string, include = [], md: any) {
   const key = content + include.join(',')


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**
Why does an LRU Class not use the new operator? Caused an error Uncaught TypeError: Class constructor LRU cannot be invoked without 'new'

i use `npm install`, the lru-cache is 5.x.  but vuepress dep is 4.x

**I found out why lru-cache became 5.x.
The reason is because @vue/cli-shared-utils uses ^5.1.1**


Source location: https://github.com/isaacs/node-lru-cache/blob/master/index.js#L27


**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of default theme, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

You have tested in the following browsers: (Providing a detailed version will be better.)

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
- [ ] IE

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature
- [ ] Related documents have been updated
- [ ] Related tests have been updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
