### PR TITLE
fix: normalize override stylus file path in windows

### DIFF
--- a/packages/@vuepress/core/lib/internal-plugins/palette/index.js
+++ b/packages/@vuepress/core/lib/internal-plugins/palette/index.js
@@ -22,6 +22,7 @@ module.exports = (options, ctx) => ({
 
     const themePalette = path.resolve(ctx.themePath, 'styles/palette.styl')
     const userPalette = path.resolve(sourceDir, '.vuepress/styles/palette.styl')
+      .replace(/[\\]+/g, '/')
 
     const themePaletteContent = fs.existsSync(themePalette)
       ? `@import(${JSON.stringify(themePalette)})`

--- a/packages/@vuepress/core/lib/internal-plugins/style/index.js
+++ b/packages/@vuepress/core/lib/internal-plugins/style/index.js
@@ -17,6 +17,7 @@ module.exports = (options, ctx) => ({
 
     const themeStyle = path.resolve(ctx.themePath, 'styles/index.styl')
     const userStyle = path.resolve(sourceDir, '.vuepress/styles/index.styl')
+      .replace(/[\\]+/g, '/')
 
     const themeStyleContent = fs.existsSync(themeStyle)
       ? `@import(${JSON.stringify(themeStyle)})`


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

You have tested in the following browsers: (Providing a detailed version will be better.)

- not browser related

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**

This is a window related bug, which was fixed in a previous version but not in `1.x.x`.
See [this pull request](https://github.com/vuejs/vuepress/pull/692) for further information