### PR TITLE
fix pagination

### DIFF
--- a/packages/@vuepress/plugin-pagination/index.js
+++ b/packages/@vuepress/plugin-pagination/index.js
@@ -5,7 +5,7 @@ function getIntervallers (max, interval) {
   const arr = [...Array(count)]
   return arr.map((v, index) => {
     const start = index * interval
-    const end = (index + 1) * interval - 1
+    const end = (index + 1) * interval
     return [start, end > max ? max : end]
   })
 }


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**
fix again pagination calculates the wrong intervallers, eg. when I have 2 posts, I pass  perPagePosts is 1. but the pagination will calculates theintervallers is ```[ [ 0, 0 ], [ 1, 1 ] ]``` instead of ```[ [ 0, 1 ], [ 1, 2 ] ]```

```javascript
const path = require('path')

module.exports = {
  name: 'vuepress-theme-ihaoze',
  plugins: [
    '@vuepress/blog',
    ['@vuepress/pagination', {
      perPagePosts: 1
    }],
    [
      '@vuepress/register-components', {
      componentsDir: [
        path.resolve(__dirname, 'components')
      ]
    }]
  ]
}
```

 
**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of default theme, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

You have tested in the following browsers: (Providing a detailed version will be better.)

- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
- [ ] IE

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature
- [ ] Related documents have been updated
- [ ] Related tests have been updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
