### PR TITLE
chore($plugin-blog): do not fallback layout in plugin

### DIFF
--- a/packages/@vuepress/plugin-blog/index.js
+++ b/packages/@vuepress/plugin-blog/index.js
@@ -1,7 +1,6 @@
 const { path, datatypes: { isString }} = require('@vuepress/shared-utils')
 
 module.exports = (options, ctx) => {
-  const { layoutComponentMap } = ctx
   const {
     pageEnhancers = [],
     postsDir = '_posts',
@@ -10,35 +9,33 @@ module.exports = (options, ctx) => {
     permalink = '/:year/:month/:day/:slug'
   } = options
 
-  const isLayoutExists = name => layoutComponentMap[name] !== undefined
-  const getLayout = (name, fallback) => isLayoutExists(name) ? name : fallback
   const isDirectChild = regularPath => path.parse(regularPath).dir === '/'
 
   const enhancers = [
     {
       when: ({ regularPath }) => regularPath === categoryIndexPageUrl,
-      frontmatter: { layout: getLayout('Categories', 'Page') }
+      frontmatter: { layout: 'Categories' }
     },
     {
       when: ({ regularPath }) => regularPath.startsWith('/category/'),
-      frontmatter: { layout: getLayout('Category', 'Page') }
+      frontmatter: { layout: 'Category' }
     },
     {
       when: ({ regularPath }) => regularPath === tagIndexPageUrl,
-      frontmatter: { layout: getLayout('Tags', 'Page') }
+      frontmatter: { layout: 'Tags' }
     },
     {
       when: ({ regularPath }) => regularPath.startsWith('/tag/'),
-      frontmatter: { layout: getLayout('Tag', 'Page') }
+      frontmatter: { layout: 'Tag' }
     },
     {
       when: ({ regularPath }) => regularPath === '/',
-      frontmatter: { layout: getLayout('Layout') }
+      frontmatter: { layout: 'Layout' }
     },
     {
       when: ({ regularPath }) => regularPath.startsWith(`/${postsDir}/`),
       frontmatter: {
-        layout: getLayout('Post', 'Page'),
+        layout: 'Post',
         permalink: permalink
       },
       data: { type: 'post' }
@@ -46,7 +43,7 @@ module.exports = (options, ctx) => {
     ...pageEnhancers,
     {
       when: ({ regularPath }) => isDirectChild(regularPath),
-      frontmatter: { layout: getLayout('Page', 'Layout') },
+      frontmatter: { layout: 'Page' },
       data: { type: 'page' }
     }
   ]


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [x] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**

Two reasons for this PR:

- It's not reasonable to fallback the layout in the frontmatter to `Page`. `Page` usually means those layouts with `<Content/>` component, but the `Tags` and `Categories` are extra pages that added in the plugin-blog with not content.
- We've already fallback layout in `LayoutDistributor`:
https://github.com/vuejs/vuepress/blob/6146287201def7cd3e4ceeb69e61faa33b583719/packages/%40vuepress/core/lib/app/components/LayoutDistributor.vue#L15-L19
