### PR TITLE
fix($plugin-blog): use index url from options for path

### DIFF
--- a/packages/@vuepress/plugin-blog/index.js
+++ b/packages/@vuepress/plugin-blog/index.js
@@ -86,15 +86,15 @@ module.exports = (options, ctx) => {
         if (key) {
           if (!map[key]) {
             map[key] = {}
-            map[key].path = `/${scope}/${key}.html`
+            map[key].path = `${scope}${key}.html`
             map[key].pageKeys = []
           }
           map[key].pageKeys.push(pageKey)
         }
       }
 
-      const handleTag = curryHandler('tag', tagMap)
-      const handleCategory = curryHandler('category', categoryMap)
+      const handleTag = curryHandler(tagIndexPageUrl, tagMap)
+      const handleCategory = curryHandler(categoryIndexPageUrl, categoryMap)
 
       pages.forEach(({
         key,


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of default theme, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No


**Other information:**

The prefix of url of the `Tag` or `Category` page should not be fixed to `/tag/` and `/category/`. They should be the same as `tagIndexPageUrl` and `categoryIndexPageUrl`.
