### PR TITLE
chore: add `repository.directory` field to each `package.json`

### DIFF
--- a/packages/@vuepress/core/package.json
+++ b/packages/@vuepress/core/package.json
@@ -5,7 +5,8 @@
   "main": "lib/index.js",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vuejs/vuepress.git"
+    "url": "git+https://github.com/vuejs/vuepress.git",
+    "directory": "packages/@vuepress/core"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/@vuepress/markdown-loader/package.json
+++ b/packages/@vuepress/markdown-loader/package.json
@@ -8,7 +8,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vuejs/vuepress.git"
+    "url": "git+https://github.com/vuejs/vuepress.git",
+    "directory": "packages/@vuepress/markdown-loader"
   },
   "keywords": [
     "documentation",

--- a/packages/@vuepress/markdown/package.json
+++ b/packages/@vuepress/markdown/package.json
@@ -8,7 +8,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vuejs/vuepress.git"
+    "url": "git+https://github.com/vuejs/vuepress.git",
+    "directory": "packages/@vuepress/markdown"
   },
   "keywords": [
     "documentation",

--- a/packages/@vuepress/plugin-active-header-links/package.json
+++ b/packages/@vuepress/plugin-active-header-links/package.json
@@ -8,7 +8,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vuejs/vuepress.git"
+    "url": "git+https://github.com/vuejs/vuepress.git",
+    "directory": "packages/@vuepress/plugin-active-header-links"
   },
   "keywords": [
     "documentation",

--- a/packages/@vuepress/plugin-back-to-top/package.json
+++ b/packages/@vuepress/plugin-back-to-top/package.json
@@ -8,7 +8,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vuejs/vuepress.git"
+    "url": "git+https://github.com/vuejs/vuepress.git",
+    "directory": "packages/@vuepress/plugin-back-to-top"
   },
   "keywords": [
     "documentation",

--- a/packages/@vuepress/plugin-blog/package.json
+++ b/packages/@vuepress/plugin-blog/package.json
@@ -8,7 +8,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vuejs/vuepress.git"
+    "url": "git+https://github.com/vuejs/vuepress.git",
+    "directory": "packages/@vuepress/plugin-blog"
   },
   "keywords": [
     "documentation",

--- a/packages/@vuepress/plugin-google-analytics/package.json
+++ b/packages/@vuepress/plugin-google-analytics/package.json
@@ -8,7 +8,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vuejs/vuepress.git"
+    "url": "git+https://github.com/vuejs/vuepress.git",
+    "directory": "packages/@vuepress/plugin-google-analytics"
   },
   "keywords": [
     "documentation",

--- a/packages/@vuepress/plugin-i18n-ui/package.json
+++ b/packages/@vuepress/plugin-i18n-ui/package.json
@@ -8,7 +8,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vuejs/vuepress.git"
+    "url": "git+https://github.com/vuejs/vuepress.git",
+    "directory": "packages/@vuepress/plugin-i18n-ui"
   },
   "keywords": [
     "documentation",

--- a/packages/@vuepress/plugin-last-updated/package.json
+++ b/packages/@vuepress/plugin-last-updated/package.json
@@ -8,7 +8,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vuejs/vuepress.git"
+    "url": "git+https://github.com/vuejs/vuepress.git",
+    "directory": "packages/@vuepress/plugin-last-updated"
   },
   "keywords": [
     "documentation",

--- a/packages/@vuepress/plugin-medium-zoom/package.json
+++ b/packages/@vuepress/plugin-medium-zoom/package.json
@@ -8,7 +8,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vuejs/vuepress.git"
+    "url": "git+https://github.com/vuejs/vuepress.git",
+    "directory": "packages/@vuepress/plugin-medium-zoom"
   },
   "keywords": [
     "documentation",

--- a/packages/@vuepress/plugin-notification/package.json
+++ b/packages/@vuepress/plugin-notification/package.json
@@ -8,7 +8,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vuejs/vuepress.git"
+    "url": "git+https://github.com/vuejs/vuepress.git",
+    "directory": "packages/@vuepress/plugin-notification"
   },
   "keywords": [
     "documentation",

--- a/packages/@vuepress/plugin-nprogress/package.json
+++ b/packages/@vuepress/plugin-nprogress/package.json
@@ -8,7 +8,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vuejs/vuepress.git"
+    "url": "git+https://github.com/vuejs/vuepress.git",
+    "directory": "packages/@vuepress/plugin-nprogress"
   },
   "keywords": [
     "documentation",

--- a/packages/@vuepress/plugin-pagination/package.json
+++ b/packages/@vuepress/plugin-pagination/package.json
@@ -8,7 +8,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vuejs/vuepress.git"
+    "url": "git+https://github.com/vuejs/vuepress.git",
+    "directory": "packages/@vuepress/plugin-pagination"
   },
   "keywords": [
     "documentation",

--- a/packages/@vuepress/plugin-pwa/package.json
+++ b/packages/@vuepress/plugin-pwa/package.json
@@ -8,7 +8,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vuejs/vuepress.git"
+    "url": "git+https://github.com/vuejs/vuepress.git",
+    "directory": "packages/@vuepress/plugin-pwa"
   },
   "keywords": [
     "documentation",

--- a/packages/@vuepress/plugin-register-components/package.json
+++ b/packages/@vuepress/plugin-register-components/package.json
@@ -8,7 +8,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vuejs/vuepress.git"
+    "url": "git+https://github.com/vuejs/vuepress.git",
+    "directory": "packages/@vuepress/plugin-register-components"
   },
   "keywords": [
     "documentation",

--- a/packages/@vuepress/plugin-search/package.json
+++ b/packages/@vuepress/plugin-search/package.json
@@ -8,7 +8,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vuejs/vuepress.git"
+    "url": "git+https://github.com/vuejs/vuepress.git",
+    "directory": "packages/@vuepress/plugin-search"
   },
   "keywords": [
     "documentation",

--- a/packages/@vuepress/shared-utils/package.json
+++ b/packages/@vuepress/shared-utils/package.json
@@ -17,7 +17,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vuejs/vuepress.git"
+    "url": "git+https://github.com/vuejs/vuepress.git",
+    "directory": "packages/@vuepress/shared-utils"
   },
   "keywords": [
     "documentation",

--- a/packages/@vuepress/test-utils/package.json
+++ b/packages/@vuepress/test-utils/package.json
@@ -7,7 +7,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vuejs/vuepress.git"
+    "url": "git+https://github.com/vuejs/vuepress.git",
+    "directory": "packages/@vuepress/test-utils"
   },
   "keywords": [
     "documentation",

--- a/packages/@vuepress/theme-blog/package.json
+++ b/packages/@vuepress/theme-blog/package.json
@@ -9,7 +9,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vuejs/vuepress.git"
+    "url": "git+https://github.com/vuejs/vuepress.git",
+    "directory": "packages/@vuepress/theme-blog"
   },
   "keywords": [
     "documentation",

--- a/packages/@vuepress/theme-default/package.json
+++ b/packages/@vuepress/theme-default/package.json
@@ -8,7 +8,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vuejs/vuepress.git"
+    "url": "git+https://github.com/vuejs/vuepress.git",
+    "directory": "packages/@vuepress/theme-default"
   },
   "keywords": [
     "documentation",

--- a/packages/@vuepress/theme-vue/package.json
+++ b/packages/@vuepress/theme-vue/package.json
@@ -9,7 +9,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vuejs/vuepress.git"
+    "url": "git+https://github.com/vuejs/vuepress.git",
+    "directory": "packages/@vuepress/theme-vue"
   },
   "keywords": [
     "documentation",

--- a/packages/vuepress/package.json
+++ b/packages/vuepress/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vuejs/vuepress.git"
+    "url": "git+https://github.com/vuejs/vuepress.git",
+    "directory": "packages/vuepress"
   },
   "keywords": [
     "documentation",


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [x] Other, please describe:

I created a similar PRs in vue-cli and vue repos, so I will just copy&paste my comment here:

This field allows you specify path of each package in a monorepo thanks to [this npm RFC](https://github.com/npm/rfcs/blob/latest/accepted/0010-monorepo-subdirectory-declaration.md). Main benefit of providing this field is a more accurate link to the package's source code from its npmjs.com page.

If changing the UI of default theme, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

You have tested in the following browsers: (Providing a detailed version will be better.)

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
- [ ] IE

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature
- [ ] Related documents have been updated
- [ ] Related tests have been updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
