### PR TITLE
feat($core): redirects for clean urls

### DIFF
--- a/packages/@vuepress/core/lib/app/app.js
+++ b/packages/@vuepress/core/lib/app/app.js
@@ -8,6 +8,7 @@ import appEnhancers from '@internal/app-enhancers'
 import globalUIComponents from '@internal/global-ui'
 import ClientComputedMixin from '@transform/ClientComputedMixin'
 import VuePress from './plugins/VuePress'
+import handleRedirect from './redirect.js'
 
 // built-in components
 import Content from './components/Content.js'
@@ -74,16 +75,7 @@ export function createApp (isServer) {
     }
   })
 
-  // redirect /foo to /foo/
-  router.beforeEach((to, from, next) => {
-    if (!/(\/|\.html)$/.test(to.path)) {
-      next(Object.assign({}, to, {
-        path: to.path + '/'
-      }))
-    } else {
-      next()
-    }
-  })
+  handleRedirect(router)
 
   const options = {}
 

--- a/packages/@vuepress/core/lib/app/app.js
+++ b/packages/@vuepress/core/lib/app/app.js
@@ -8,7 +8,7 @@ import appEnhancers from '@internal/app-enhancers'
 import globalUIComponents from '@internal/global-ui'
 import ClientComputedMixin from '@transform/ClientComputedMixin'
 import VuePress from './plugins/VuePress'
-import handleRedirect from './redirect.js'
+import { handleRedirectForCleanUrls } from './redirect.js'
 
 // built-in components
 import Content from './components/Content.js'
@@ -75,7 +75,7 @@ export function createApp (isServer) {
     }
   })
 
-  handleRedirect(router)
+  handleRedirectForCleanUrls(router)
 
   const options = {}
 

--- a/packages/@vuepress/core/lib/app/redirect.js
+++ b/packages/@vuepress/core/lib/app/redirect.js
@@ -1,0 +1,57 @@
+// In VuePress, we have following convention about routing:
+//
+//   - `/foo/` means source file is `/foo/{README|index}.md`
+//   - `/foo.html` means your source file is `/foo.md`
+//
+// The original design of VuePress relied on above two styles
+// of routing, especially the routing calculations involved in
+// default theme. so we can't easily modify `/foo.html` directly
+// to `/foo` (i.e. remove html suffix)
+//
+// This "temporary" utility handles redirect of clean urls, with
+// this utility, you'll get:
+//
+// For unknown request `/foo`
+//   - redirect to `/foo.html` if it exists
+//   - redirect to `/foo/` if it exists
+//
+// For unknown request `/foo/`
+//   - redirect to `/foo.html` if it exists
+
+export default function handleRedirect (router) {
+  router.beforeEach((to, from, next) => {
+    if (isRouteExists(router, to.path)) {
+      next()
+    } else {
+      // For unknown request `/foo`
+      // redirect to /foo/ if exists
+      // redirect to /foo.html if exists
+      if (!/(\/|\.html)$/.test(to.path)) {
+        const endingSlashUrl = to.path + '/'
+        const endingHtmlUrl = to.path + '.html'
+        if (isRouteExists(router, endingHtmlUrl)) {
+          next(endingHtmlUrl)
+        } else if (isRouteExists(router, endingSlashUrl)) {
+          next(endingSlashUrl)
+        } else {
+          next()
+        }
+        // For unknown request `/foo/`
+        // redirect to /foo.html if exists
+      } else if (/\/$/.test(to.path)) {
+        const endingHtmlUrl = to.path.replace(/\/$/, '') + '.html'
+        if (isRouteExists(router, endingHtmlUrl)) {
+          next(endingHtmlUrl)
+        } else {
+          next()
+        }
+      } else {
+        next()
+      }
+    }
+  })
+}
+
+function isRouteExists (router, path) {
+  return router.options.routes.filter(route => route.path === path).length > 0
+}

--- a/packages/@vuepress/core/lib/app/redirect.js
+++ b/packages/@vuepress/core/lib/app/redirect.js
@@ -4,7 +4,7 @@
 //   - `/foo.html` means your source file is `/foo.md`
 //
 // The original design of VuePress relied on above two styles
-// of routing, especially the routing calculations involved in
+// of routing, especially the calculation involved of routes at
 // default theme. so we can't easily modify `/foo.html` directly
 // to `/foo` (i.e. remove html suffix)
 //
@@ -17,15 +17,14 @@
 //
 // For unknown request `/foo/`
 //   - redirect to `/foo.html` if it exists
+//
+// If all the above redirect rules don't exist, you'll get a 404
 
-export default function handleRedirect (router) {
+export function handleRedirectForCleanUrls (router) {
   router.beforeEach((to, from, next) => {
     if (isRouteExists(router, to.path)) {
       next()
     } else {
-      // For unknown request `/foo`
-      // redirect to /foo/ if exists
-      // redirect to /foo.html if exists
       if (!/(\/|\.html)$/.test(to.path)) {
         const endingSlashUrl = to.path + '/'
         const endingHtmlUrl = to.path + '.html'
@@ -36,8 +35,6 @@ export default function handleRedirect (router) {
         } else {
           next()
         }
-        // For unknown request `/foo/`
-        // redirect to /foo.html if exists
       } else if (/\/$/.test(to.path)) {
         const endingHtmlUrl = to.path.replace(/\/$/, '') + '.html'
         if (isRouteExists(router, endingHtmlUrl)) {


### PR DESCRIPTION
## Summary 

In VuePress, we have following convention about routing:

   - `/foo/` means source file is `/foo/{README|index}.md`
   - `/foo.html` means your source file is `/foo.md`

 The original design of VuePress relied on above two styles
 of routing, especially the calculation involved of routes at
// default theme. so we can't easily modify `/foo.html` directly
 to `/foo` (i.e. remove html suffix)

 This  utility handles redirect of clean urls, with this utility, you'll
 get:

 For unknown request `/foo`
   - redirect to `/foo.html` if it exists
   - redirect to `/foo/` if it exists

 For unknown request `/foo/`
   - redirect to `/foo.html` if it exists

If all the above redirect rules don't exist, you'll get a 404

---

**Note that** this PR doesn't provide you the ability to remove the
html suffix at the route level, it just allows you to use clean urls.

cc @octref 

---

Related: #603 
Related: #608
Related: #1060
Close: #720 
Close: #931 


