### PR TITLE
Fix Bit sponsor image

### DIFF
--- a/packages/docs/docs/.vuepress/components/Bit.vue
+++ b/packages/docs/docs/.vuepress/components/Bit.vue
@@ -2,7 +2,7 @@
   <p class="bit-sponsor">
     <a href="https://www.bitsrc.io/?utm_source=vue&utm_medium=vue&utm_campaign=vue&utm_term=vue&utm_content=vue" target="_blank">
       <span>This project is sponsored by</span>
-      <img alt="bit" src="https://raw.githubusercontent.com/vuejs/vuejs.org/master/themes/vue/source/images/bit-wide.png">
+      <img alt="bit" src="https://raw.githubusercontent.com/vuejs/vuejs.org/master/themes/vue/source/images/bit.png">
     </a>
   </p>
 </template>


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

The docs site currently points to a Bit (bitsrc.io) sponsor logo asset at https://raw.githubusercontent.com/vuejs/vuejs.org/master/themes/vue/source/images/bit-wide.png which [does not](https://github.com/vuejs/vuejs.org/blob/master/themes/vue/_config.yml) [exist](https://github.com/vuejs/vuejs.org/tree/master/themes/vue/source/images) in the vuejs/vuejs.org repo causing a 404 (see screenshot below).  This PR points it to the similarly name asset that _does_ exist.

<img width="1403" alt="screen shot 2019-02-11 at 10 09 11 pm" src="https://user-images.githubusercontent.com/366688/52609087-14076f80-2e4a-11e9-9a6f-917a4f68d6ee.png">

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [x] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of default theme, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

You have tested in the following browsers: (Providing a detailed version will be better.)

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
- [ ] IE

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature
- [ ] Related documents have been updated
- [ ] Related tests have been updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
