### PR TITLE
Proposal: Hero Header should allow for optional h1 text

### DIFF
--- a/packages/@vuepress/theme-default/components/Home.vue
+++ b/packages/@vuepress/theme-default/components/Home.vue
@@ -4,10 +4,10 @@
       <img
         v-if="data.heroImage"
         :src="$withBase(data.heroImage)"
-        alt="hero"
+        :alt="data.heroAlt || 'hero'"
       >
 
-      <h1 id="main-title">{{ data.heroText || $title || 'Hello' }}</h1>
+      <h1 v-if="data.heroText !== null" id="main-title">{{ data.heroText || $title || 'Hello' }}</h1>
 
       <p class="description">
         {{ data.tagline || $description || 'Welcome to your VuePress site' }}


### PR DESCRIPTION
this is useful when `data.heroImage` can act as the "header" _(e.g. logo & label of product / application are present in image)_

- allow removing the h1 tag when `data.heroText` is `NULL`
- allow passing `data.heroAlt` to define alt text value.

<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of default theme, please provide the **before/after** screenshot:

###### Before

![image](https://user-images.githubusercontent.com/183195/53188716-01243600-35d4-11e9-8f10-17198aeaf280.png)


#### After 

> with `data.heroText === null`

![image](https://user-images.githubusercontent.com/183195/53188785-139e6f80-35d4-11e9-912a-948f4317fcf4.png)

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

You have tested in the following browsers: (Providing a detailed version will be better.)

- [x] Chrome
- [x] Firefox
- [x] Safari
- [x] Edge
- [ x IE

If adding a **new feature**, the PR's description includes:

- [x] A convincing reason for adding this feature
- [ ] Related documents have been updated
  - I have not updated docs yet, but I will if this is given 👍 
- [ ] Related tests have been updated
  - this will need new tests, happy to provide them if this is given 👍 

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
