### PR TITLE
refactor($theme-default): prev/next page link (close #1327)

### DIFF
--- a/packages/@vuepress/theme-default/components/Page.vue
+++ b/packages/@vuepress/theme-default/components/Page.vue
@@ -34,7 +34,6 @@
         >
           ←
           <router-link
-            class="prev"
             :to="prev.path"
             v-text="prev.title || prev.path"
           />
@@ -45,7 +44,6 @@
           class="next"
         >
           <router-link
-            class="next"
             :to="next.path"
             v-text="next.title || next.path"
           />


### PR DESCRIPTION
**Summary**

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [x] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of default theme, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

You have tested in the following browsers: (Providing a detailed version will be better.)

- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
- [ ] IE

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature
- [ ] Related documents have been updated
- [ ] Related tests have been updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**

If we use

```vue
<router-link
  class="prev"
  :to="prev.path"
>
  {{ prev.title || prev.path }}
</router-link>
```

The path of router-link will be updated when page updates, however this innerText will be never changed.

If we use

```vue
<router-link
  class="prev"
  :to="prev.path"
  v-text="prev.title || prev.path"
/>
```

instead, everything go on smoothly. I don't understand what caused this.