### PR TITLE
feat: plugin clean urls

### DIFF
--- a/packages/@vuepress/plugin-clean-urls/.npmignore
+++ b/packages/@vuepress/plugin-clean-urls/.npmignore
@@ -1,0 +1,3 @@
+__tests__
+__mocks__
+.temp

--- a/packages/@vuepress/plugin-clean-urls/README.md
+++ b/packages/@vuepress/plugin-clean-urls/README.md
@@ -1,0 +1,5 @@
+# @vuepress/plugin-clean-urls
+
+> clean urls plugin for vuepress
+
+See [documentation](https://vuepress.vuejs.org/plugin/official/plugin-clean-urls.html).

--- a/packages/@vuepress/plugin-clean-urls/index.js
+++ b/packages/@vuepress/plugin-clean-urls/index.js
@@ -8,9 +8,15 @@ module.exports = (options = {}, context) => {
     extendPageData (page) {
       const { regularPath, frontmatter = {}} = page
       if (frontmatter.permalink) return
-      page.path = regularPath
-        .replace(/\.html$/, normalSuffix)
-        .replace(/\/$/, indexSuffix)
+      if (regularPath.endsWith('.html')) {
+        // normal path
+        // e.g. foo/bar.md -> foo/bar.html
+        page.path = regularPath.slice(0, -5) + normalSuffix
+      } else if (regularPath.endsWith('/')) {
+        // index path
+        // e.g. foo/index.md -> foo/
+        page.path = regularPath.slice(0, -1) + indexSuffix
+      }
     }
   }
 }

--- a/packages/@vuepress/plugin-clean-urls/index.js
+++ b/packages/@vuepress/plugin-clean-urls/index.js
@@ -1,0 +1,16 @@
+module.exports = (options = {}, context) => {
+  const {
+    normalSuffix = '',
+    indexSuffix = '/'
+  } = options
+
+  return {
+    extendPageData (page) {
+      const { regularPath, frontmatter = {}} = page
+      if (frontmatter.permalink) return
+      page.path = regularPath
+        .replace(/\.html$/, normalSuffix)
+        .replace(/\/$/, indexSuffix)
+    }
+  }
+}

--- a/packages/@vuepress/plugin-clean-urls/package.json
+++ b/packages/@vuepress/plugin-clean-urls/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@vuepress/plugin-clean-urls",
+  "version": "1.0.0-alpha.39",
+  "description": "clean urls plugin for vuepress",
+  "main": "index.js",
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/vuejs/vuepress.git",
+    "directory": "packages/@vuepress/plugin-clean-urls"
+  },
+  "keywords": [
+    "documentation",
+    "vue",
+    "vuepress",
+    "generator"
+  ],
+  "author": "Shigma <1700011071@pku.edu.cn>",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/vuejs/vuepress/issues"
+  },
+  "homepage": "https://github.com/vuejs/vuepress/packages/@vuepress/plugin-clean-urls#readme"
+}

--- a/packages/docs/docs/.vuepress/config.js
+++ b/packages/docs/docs/.vuepress/config.js
@@ -143,6 +143,7 @@ function getPluginSidebar (pluginTitle, pluginIntro, officialPluginTitle) {
         'official/plugin-medium-zoom',
         'official/plugin-back-to-top',
         'official/plugin-register-components',
+        'official/plugin-clean-urls'
       ]
     }
   ]

--- a/packages/docs/docs/plugin/official/plugin-clean-urls.md
+++ b/packages/docs/docs/plugin/official/plugin-clean-urls.md
@@ -1,0 +1,51 @@
+---
+title: clean-urls
+metaTitle: A plugin of automatically generating clean urls | VuePress
+---
+
+# [@vuepress/plugin-clean-urls](https://github.com/vuejs/vuepress/tree/master/packages/@vuepress/plugin-clean-urls)
+
+> A plugin of automatically generating clean urls
+
+## Install
+
+```bash
+yarn add -D @vuepress/plugin-clean-urls
+# OR npm install -D @vuepress/plugin-clean-urls
+```
+
+## Usage
+
+```javascript
+module.exports = {
+  plugins: ['@vuepress/clean-urls'] 
+}
+```
+
+## Options
+
+### normalSuffix
+
+- Type: `string`
+- Default: `''`
+
+The suffix for normal pages. For example, `foo/bar.md` will become:
+
+- `foo/bar.html` by default (without this plugin)
+- `foo/bar/` (with `normalSuffix` set to `'/'`)
+- `foo/bar` (with `normalSuffix` set to `''`)
+
+### indexSuffix
+
+- Type: `string`
+- Default: `'/'`
+
+The suffix for index pages. For example, `foo/index.md` will become:
+
+- `foo/` by default (without this plugin)
+- `foo` (with `indexSuffix` set to `''`)
+- `foo/index.html` (with `indexSuffix` set to `'/index.html'`)
+
+::: tip
+An index page is a page with a file name of index.md or readme.md (case insensitive).
+:::

--- a/packages/docs/docs/zh/plugin/official/plugin-clean-urls.md
+++ b/packages/docs/docs/zh/plugin/official/plugin-clean-urls.md
@@ -1,0 +1,51 @@
+---
+title: clean-urls
+metaTitle: 自动生成简洁链接的插件 | VuePress
+---
+
+# [@vuepress/plugin-clean-urls](https://github.com/vuejs/vuepress/tree/master/packages/@vuepress/plugin-clean-urls)
+
+> 自动生成简洁链接的插件
+
+## 安装
+
+```bash
+yarn add -D @vuepress/plugin-clean-urls
+# OR npm install -D @vuepress/plugin-clean-urls
+```
+
+## 使用
+
+```javascript
+module.exports = {
+  plugins: ['@vuepress/clean-urls'] 
+}
+```
+
+## 选项
+
+### normalSuffix
+
+- 类型: `string`
+- 默认值: `''`
+
+普通页面的链接后缀。举个例子，`foo/bar.md` 会自动变成：
+
+- `foo/bar.html` 在默认情况下（未安装本插件时）
+- `foo/bar/`（当 `normalSuffix` 被设为 `'/'` 时）
+- `foo/bar`（当 `normalSuffix` 被设为 `''` 时）
+
+### indexSuffix
+
+- 类型: `string`
+- 默认值: `'/'`
+
+索引页面的链接后缀。举个例子，`foo/index.md` 会自动变成：
+
+- `foo/` 在默认情况下（未安装本插件时）
+- `foo`（当 `indexSuffix` 被设为 `''` 时）
+- `foo/index.html`（当 `indexSuffix` 被设为 `'/index.html'` 时）
+
+::: tip
+索引页面是指文件名为 index.md 或者 readme.md 的页面（不区分大小写）。
+:::


### PR DESCRIPTION
**Summary**

Add a new plugin `@vuepress/vuepress-plugin-clean-urls`.

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of default theme, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

You have tested in the following browsers: (Providing a detailed version will be better.)

- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
- [ ] IE

If adding a **new feature**, the PR's description includes:

- [x] A convincing reason for adding this feature (#608 )
- [x] Related documents have been updated
- [ ] Related tests have been updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**

This plugin supports two options:

### normalSuffix

- Type: `string`
- Default: `''`

The suffix for normal pages. For example, `foo/bar.md` will become:

- `foo/bar.html` by default (without this plugin)
- `foo/bar/` (with `normalSuffix` set to `'/'`)
- `foo/bar` (with `normalSuffix` set to `''`)

### indexSuffix

- Type: `string`
- Default: `'/'`

The suffix for index pages. For example, `foo/index.md` will become:

- `foo/` by default (without this plugin)
- `foo` (with `indexSuffix` set to `''`)
- `foo/index.html` (with `indexSuffix` set to `'/index.html'`)