### PR TITLE
fix #1367: Generate runnable output when source-map is enabled

### DIFF
--- a/packages/@vuepress/core/lib/build.js
+++ b/packages/@vuepress/core/lib/build.js
@@ -47,7 +47,9 @@ module.exports = async function build (sourceDir, cliOptions = {}) {
   // find and remove empty style chunk caused by
   // https://github.com/webpack-contrib/mini-css-extract-plugin/issues/85
   // TODO remove when it's fixed
-  await workaroundEmptyStyleChunk()
+  if (!clientConfig.devtool && (!clientConfig.plugins || !clientConfig.plugins.some(p => p instanceof webpack.SourceMapDevToolPlugin || p instanceof webpack.EvalSourceMapDevToolPlugin))) {
+    await workaroundEmptyStyleChunk()
+  }
 
   // create server renderer using built manifests
   const renderer = createBundleRenderer(serverBundle, {

--- a/packages/@vuepress/core/lib/build.js
+++ b/packages/@vuepress/core/lib/build.js
@@ -47,7 +47,11 @@ module.exports = async function build (sourceDir, cliOptions = {}) {
   // find and remove empty style chunk caused by
   // https://github.com/webpack-contrib/mini-css-extract-plugin/issues/85
   // TODO remove when it's fixed
-  if (!clientConfig.devtool && (!clientConfig.plugins || !clientConfig.plugins.some(p => p instanceof webpack.SourceMapDevToolPlugin || p instanceof webpack.EvalSourceMapDevToolPlugin))) {
+  if (!clientConfig.devtool && (!clientConfig.plugins ||           
+    !clientConfig.plugins.some(p =>
+      p instanceof webpack.SourceMapDevToolPlugin ||
+      p instanceof webpack.EvalSourceMapDevToolPlugin
+    ))) {
     await workaroundEmptyStyleChunk()
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6568,7 +6568,7 @@ markdown-it-anchor@^5.0.2:
 
 markdown-it-chain@^1.3.0:
   version "1.3.0"
-  resolved "http://registry.npm.taobao.org/markdown-it-chain/download/markdown-it-chain-1.3.0.tgz#ccf6fe86c10266bafb4e547380dfd7f277cc17bc"
+  resolved "https://registry.yarnpkg.com/markdown-it-chain/-/markdown-it-chain-1.3.0.tgz#ccf6fe86c10266bafb4e547380dfd7f277cc17bc"
   dependencies:
     webpack-chain "^4.9.0"
 


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**
This pr addresses the issue #1367. When source-map is enabled, the previous implementation won't generate runnable output.
This build-related fix manages to generate runnable output when source-map is enabled at the price of an additional unnecessary chunk. However, source-map in production mode is mainly used to debug production bundle, thus does not affect normal users.

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [x] Build-related changes
- [ ] Other, please describe:

If changing the UI of default theme, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

You have tested in the following browsers: (Providing a detailed version will be better.)

- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
- [ ] IE

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature
- [ ] Related documents have been updated
- [ ] Related tests have been updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
