### PR TITLE
fix: Do not register component in render function

### DIFF
--- a/packages/@vuepress/core/lib/client/components/Content.js
+++ b/packages/@vuepress/core/lib/client/components/Content.js
@@ -13,8 +13,7 @@ export default {
     const pageKey = this.pageKey || this.$parent.$page.key
     const pageComponent = getPageAsyncComponent(pageKey)
     if (pageComponent) {
-      Vue.component(pageKey, pageComponent)
-      return h(pageKey)
+      return h(pageComponent)
     }
     return h('')
   }


### PR DESCRIPTION
Registering component in render function is throwing unknown component. In fact, there is no need to register component as `h` can accept async factory (async component)

<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of default theme, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

You have tested in the following browsers: (Providing a detailed version will be better.)

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
- [ ] IE

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature
- [ ] Related documents have been updated
- [ ] Related tests have been updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
