### PR TITLE
Fix side navigation edge case bug introduced in #1475

### DIFF
--- a/packages/@vuepress/plugin-active-header-links/clientRootMixin.js
+++ b/packages/@vuepress/plugin-active-header-links/clientRootMixin.js
@@ -40,12 +40,12 @@ export default {
 
         const routeHash = decodeURIComponent(this.$route.hash)
         if (isActive && routeHash !== decodeURIComponent(anchor.hash)) {
-          let activeAnchor = anchor
+          const activeAnchor = anchor
           // check if anchor is at the bottom of the page to keep $route.hash consistent
           if (bottomY === scrollHeight) {
             for (let j = i + 1; j < anchors.length; j++) {
               if (routeHash === decodeURIComponent(anchors[j].hash)) {
-                activeAnchor = anchors[j]
+                return
               }
             }
           }


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**
In some cases, the code from #1475 can render the page unable to scroll in response to a click in the side navigation.

**Issue:**
![demonstration of the issue](https://user-images.githubusercontent.com/2942084/54888213-5d3edc00-4e58-11e9-9bde-966614edb12f.gif)

**Fixed:**
![demonstration of the resolution](https://user-images.githubusercontent.com/2942084/54888217-64fe8080-4e58-11e9-95af-da9d8ab12c10.gif)



**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of default theme, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

You have tested in the following browsers: (Providing a detailed version will be better.)

- [x] Chrome
- [x] Firefox
- [x] Safari
- [ ] Edge
- [ ] IE

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature
- [ ] Related documents have been updated
- [ ] Related tests have been updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
This is information in the file `packages/@vuepress/plugin-active-header-links/clientRootMixin.js`
 
The bug comes from the fact that the call to `this.$router.replace` fails if there is nothing in the URL to replace. Since `disableScrollBehavior` is set to `true` before this call, and `disableScrollBehavior` is set to `false` in the callback for `this.$router.replace`, the navigation links would not be allowed to scroll if the function fails and the callback is never reached. The only way to get out of this state would be to scroll manually, forcing `disableScrollBehavior` to be reset to `false`.  Since the `replace` call fails anyway, simply returning out of the function if there is a match for the element at the bottom of the screen gets around this issue.