### PR TITLE
feat($core): prevent duplicate route

### DIFF
--- a/packages/@vuepress/core/lib/node/App.js
+++ b/packages/@vuepress/core/lib/node/App.js
@@ -351,9 +351,7 @@ module.exports = class App {
     const index = this.pages.findIndex(({ path }) => path === page.path)
     if (index >= 0) {
       // override a page if corresponding path already exists
-      if (!this.pages[index].overridable) {
-        logger.warn(`Override existing page ${chalk.yellow(page.path)}.`)
-      }
+      logger.warn(`Override existing page ${chalk.yellow(page.path)}.`)
       this.pages.splice(index, 1, page)
     } else {
       this.pages.push(page)

--- a/packages/@vuepress/core/lib/node/App.js
+++ b/packages/@vuepress/core/lib/node/App.js
@@ -350,6 +350,10 @@ module.exports = class App {
     })
     const index = this.pages.findIndex(({ path }) => path === page.path)
     if (index >= 0) {
+      // override a page if corresponding path already exists
+      if (!this.pages[index].overridable) {
+        logger.warn(`Override existing page ${chalk.yellow(page.path)}.`)
+      }
       this.pages.splice(index, 1, page)
     } else {
       this.pages.push(page)

--- a/packages/@vuepress/core/lib/node/App.js
+++ b/packages/@vuepress/core/lib/node/App.js
@@ -350,7 +350,7 @@ module.exports = class App {
     })
     const index = this.pages.findIndex(({ path }) => path === page.path)
     if (index >= 0) {
-      // override a page if corresponding path already exists
+      // Override a page if corresponding path already exists
       logger.warn(`Override existing page ${chalk.yellow(page.path)}.`)
       this.pages.splice(index, 1, page)
     } else {

--- a/packages/@vuepress/core/lib/node/App.js
+++ b/packages/@vuepress/core/lib/node/App.js
@@ -348,7 +348,12 @@ module.exports = class App {
       computed: new this.ClientComputedMixinConstructor(),
       enhancers: this.pluginAPI.getOption('extendPageData').items
     })
-    this.pages.push(page)
+    const index = this.pages.findIndex(({ path }) => path === page.path)
+    if (index >= 0) {
+      this.pages.splice(index, 1, page)
+    } else {
+      this.pages.push(page)
+    }
   }
 
   /**


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

If we add multiple pages with the same path (i.e. theme has already provided a homepage but we want to override it), VuePress client will break with the following message:

```
[vue-router] Duplicate named routes definition: { name: "v-b2754d56", path: "" }
```

This PR prevent from adding duplicate route. If a duplicate route was to be add, it will override the old one.

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of default theme, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

You have tested in the following browsers: (Providing a detailed version will be better.)

- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
- [ ] IE

If adding a **new feature**, the PR's description includes:

- [x] A convincing reason for adding this feature
- [ ] Related documents have been updated
- [ ] Related tests have been updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
