### PR TITLE
feat(options): make enhancers async ready without breaking changes

### DIFF
--- a/packages/@vuepress/core/lib/node/Page.js
+++ b/packages/@vuepress/core/lib/node/Page.js
@@ -282,14 +282,14 @@ module.exports = class Page {
    * @api private
    */
 
-  enhance (enhancers) {
-    return enhancers.reduce(async (accumulator, { pluginName, value }) => {
-      return accumulator
-        .then(() => value(this))
-        .catch(error => {
-          console.log(error)
-          throw new Error(`[${pluginName}] execute extendPageData failed.`)
-        })
-    }, Promise.resolve())
+  async enhance (enhancers) {
+    for (const { name: pluginName, value: enhancer } of enhancers) {
+      try {
+        await enhancer(this)
+      } catch (error) {
+        console.log(error)
+        throw new Error(`[${pluginName}] execute extendPageData failed.`)
+      }
+    }
   }
 }

--- a/packages/@vuepress/core/lib/node/Page.js
+++ b/packages/@vuepress/core/lib/node/Page.js
@@ -142,7 +142,7 @@ module.exports = class Page {
     this._computed = computed
     this._localePath = computed.$localePath
 
-    this.enhance(enhancers)
+    await this.enhance(enhancers)
     this.buildPermalink()
   }
 
@@ -283,13 +283,13 @@ module.exports = class Page {
    */
 
   enhance (enhancers) {
-    for (const { name: pluginName, value: enhancer } of enhancers) {
-      try {
-        enhancer(this)
-      } catch (error) {
-        console.log(error)
-        throw new Error(`[${pluginName}] excuete extendPageData failed.`)
-      }
-    }
+    return enhancers.reduce(async (accumulator, { pluginName, value }) => {
+      return accumulator
+        .then(() => value(this))
+        .catch(error => {
+          console.log(error)
+          throw new Error(`[${pluginName}] execute extendPageData failed.`)
+        })
+    }, Promise.resolve())
   }
 }

--- a/packages/@vuepress/core/lib/node/__tests__/prepare/Page.spec.js
+++ b/packages/@vuepress/core/lib/node/__tests__/prepare/Page.spec.js
@@ -102,5 +102,54 @@ describe('Page', () => {
     expect(page._content.startsWith('---')).toBe(true)
     expect(page._strippedContent.startsWith('---')).toBe(false)
   })
+
+  describe('enhance - ', () => {
+    let page
+    let enhancers
+
+    beforeEach(() => {
+      page = new Page({ path: '/' }, app)
+      enhancers = [
+        {
+          pluginName: 'foo',
+          value: jest.fn()
+        },
+        {
+          pluginName: 'foo',
+          value: jest.fn()
+        }
+      ]
+      global.console.log = jest.fn()
+    })
+
+    test('should loop over sync enhancers', async () => {
+      await page.enhance(enhancers)
+
+      return enhancers.map(enhancer => expect(enhancer.value).toBeCalled())
+    })
+
+    test('should loop over sync and async enhancers', async () => {
+      const mixedEnhancers = [...enhancers, {
+        pluginName: 'blog',
+        value: jest.fn().mockResolvedValue({})
+      }]
+      await page.enhance(mixedEnhancers)
+
+      return mixedEnhancers.map(enhancer => expect(enhancer.value).toBeCalled())
+    })
+
+    test('should log when enhancing when failing', async () => {
+      const error = { errorMessage: 'this is an error message' }
+      expect.assertions(1)
+      try {
+        await page.enhance([{
+          pluginName: 'error-plugin',
+          value: jest.fn().mockRejectedValue(error)
+        }])
+      } catch (e) {
+        expect(console.log).toBeCalledWith(error)
+      }
+    })
+  })
 })
 

--- a/packages/docs/docs/plugin/option-api.md
+++ b/packages/docs/docs/plugin/option-api.md
@@ -280,7 +280,7 @@ import { SOURCE_DIR } from '@dynamic/constants'
 
 ## extendPageData
 
-- Type: `Function`
+- Type: `Function|AsyncFunction`
 - Default: `undefined`
 
 A function used to extend or edit the [$page](../guide/global-computed.md#page) object. This function will be invoking once for each page at compile time.
@@ -304,6 +304,16 @@ module.exports = {
 
     // 2. Change frontmatter.
     frontmatter.sidebar = 'auto'
+  }
+}
+```
+
+Note that `extendPageData` can also be defined as an asynchronous function.
+
+```js
+module.exports = {
+  async extendPageData ($page) {
+    $page.xxx = await getAsyncData()
   }
 }
 ```


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of default theme, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

You have tested in the following browsers: (Providing a detailed version will be better.)

- [x] Chrome
- [x] Firefox
- [x] Safari
- [ ] Edge
- [ ] IE

If adding a **new feature**, the PR's description includes:

- [x] A convincing reason for adding this feature
- [ ] Related documents have been updated
**There is no dedicated documentation for async options for now**
- [x] Related tests have been updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**

I am working on a project where I use vuepress alpha.47. I am trying to fetch dynamically information for `$page` data base on a `frontmatter` value.

Here is the code of the plugin I am trying to introduce in my project.

```js
const { fetchUser } = require('./service');

module.exports = () => {
  const authors = {};

  return {
    name: "github",

    async extendPageData($page) {
      if($page.frontmatter.type === "post") {
        const githubProfile = $page.frontmatter.github_profile;

        if(!authors[githubProfile]){
          const fetched = await fetchUser(githubProfile); 
          authors[githubProfile] = fetched;

          $page.frontmatter.gh = fetched;
          return $page;
        }
      }
      return $page;
    }
  }
};
```

But extendPageData is not async ready for now.
So this is my contribution to make is async ready 🎉

Tested  locally with `yarn link`