### PR TITLE
fix slugify: markdown header sections containing only special chars

### DIFF
--- a/packages/@vuepress/shared-utils/src/slugify.ts
+++ b/packages/@vuepress/shared-utils/src/slugify.ts
@@ -19,6 +19,8 @@ export = function slugify (str: string): string {
     .replace(/^\-+|\-+$/g, '')
     // ensure it doesn't start with a number (#121)
     .replace(/^(\d)/, '_$1')
+    // ensure it isn't empty, breaking scrolling and sidebar
+    .replace(/^$/, '_')
     // lowercase
     .toLowerCase()
 }


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

Markdown header sections that contain only specials characters like `<<`, `->`
or even `?` (as used for function descriptions in the Gerbil Scheme Reference
Docs) end up empty, breaking scrolling, search and sidebar navigation.

Replacing the empty result with an underscore, similar to what happens with
numbers in the front position, fixes all of these problems.

To see the problem in action, go to  https://cons.io/reference/actor.html#message-primitives
and scroll down. It will jump to the top of the page. Furthermore, clicking on links 
these links in the sidebar does nothing, same thing with the search field in 
the navigation bar.

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of default theme, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

You have tested in the following browsers: (Providing a detailed version will be better.)

- [x] Chrome (latest stable)
- [x] Firefox (latest stable)
- [ ] Safari
- [ ] Edge
- [ ] IE

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature
- [ ] Related documents have been updated
- [ ] Related tests have been updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
