### PR TITLE
fix($last-updated): use file author time instead of submodule commit time (1.x)

### DIFF
--- a/packages/@vuepress/plugin-last-updated/index.js
+++ b/packages/@vuepress/plugin-last-updated/index.js
@@ -1,3 +1,4 @@
+const path = require('path')
 const spawn = require('cross-spawn')
 
 module.exports = (options = {}, context) => ({
@@ -21,7 +22,11 @@ function defaultTransformer (timestamp, lang) {
 function getGitLastUpdatedTimeStamp (filePath) {
   let lastUpdated
   try {
-    lastUpdated = parseInt(spawn.sync('git', ['log', '-1', '--format=%ct', filePath]).stdout.toString('utf-8')) * 1000
+    lastUpdated = parseInt(spawn.sync(
+      'git',
+      ['log', '-1', '--format=%at', path.basename(filePath)],
+      { cwd: path.dirname(filePath) }
+    ).stdout.toString('utf-8')) * 1000
   } catch (e) { /* do not handle for now */ }
   return lastUpdated
 }


### PR DESCRIPTION
**Summary**
When using a Git submodule, the "last updated" time for all files within that submodule is incorrect.

This happens because the `git log` command, when operating from a working directory that is part of the parent repository, only operates on that parent repository. As a result, any query for the log for a specific file that is located in a submodule will return the log for the submodule entry itself.

So, for example, if we have a submodule `/foo` and a file `/foo/bar.md`, then even if `bar.md` was last updated many years ago, if we commited a update of the submodule five minutes ago that will cause Vuepress to show that `bar.md` was last updated 5 minutes ago, while in fact it hasn't.

This pull request resolves this bug by first changing the current working directory to the directory containing the file, so that if the file is part of a submodule, `git log` accesses the log of the submodule and retrieves the correct last updated time from that files history instead of only considering the submodule history of the parent repository. This of course also works the same for repositories without submodules so does not require any additional checks or workarounds.

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**The PR fulfills these requirements:**

- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

You have tested in the following browsers: (Providing a detailed version will be better.)

- [ ] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge
- [ ] IE
- [x] Checked generated code in text editor

**Other information:**
I've also opened a pull request with the exact same changes for `0.x`, see #1639.