### PR TITLE
Remove parentheses around site url

### DIFF
--- a/packages/@vuepress/core/lib/node/webpack/DevLogPlugin.js
+++ b/packages/@vuepress/core/lib/node/webpack/DevLogPlugin.js
@@ -33,7 +33,7 @@ module.exports = class DevLogPlugin {
         + (
           isFirst
             ? ''
-            : `${chalk.gray(`(${displayUrl})`)}`
+            : `${chalk.gray(`${displayUrl}`)}`
         )
       )
       if (isFirst) {


### PR DESCRIPTION
As VSCode makes `http://localhost:8080/)` including trailing parentheses which leads to a 404.

<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [] Build-related changes
- [x] Other, please describe: DX for clicking on the local URL in Vs Code

If changing the UI of default theme, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

You have tested in the following browsers: (Providing a detailed version will be better.)

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
- [ ] IE

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature
- [ ] Related documents have been updated
- [ ] Related tests have been updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
