### PR TITLE
Add a "searchbox" slot to Navbar.vue

### DIFF
--- a/packages/@vuepress/theme-default/components/Navbar.vue
+++ b/packages/@vuepress/theme-default/components/Navbar.vue
@@ -31,6 +31,8 @@
         :options="algolia"
       />
       <SearchBox v-else-if="$site.themeConfig.search !== false && $page.frontmatter.search !== false"/>
+      <slot name="searchbox"/>
+
       <NavLinks class="can-hide"/>
     </div>
   </header>


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**
This adds `searchbox` slot the Navbar.vue component to allow for more easily overriding the default search plugin(s) without needing to override the Navbar.vue component itself.

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [x] Other, please describe:

It's _kind_ of a feature, it's just a slot so I can keep from overriding the navbar itself when implementing custom search.

If changing the UI of default theme, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

You have tested in the following browsers: (Providing a detailed version will be better.)

- [x] Chrome 74.0.3729.169
- [ ] Firefox
- [ ] Safari
- [ ] Edge
- [ ] IE

If adding a **new feature**, the PR's description includes:

- [x] A convincing reason for adding this feature
- [x] Related documents have been updated
- [x] Related tests have been updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
