### PR TITLE
fix: fix 'Unknown custom element' without any content (#1426)

### DIFF
--- a/packages/@vuepress/core/lib/client/components/Content.js
+++ b/packages/@vuepress/core/lib/client/components/Content.js
@@ -21,7 +21,7 @@ export default {
       Vue.component(pageKey, getPageAsyncComponent(pageKey))
     }
 
-    if (pageKey) {
+    if (Vue.component(pageKey)) {
       return h(pageKey)
     }
     return h('')


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

**Bug**: example, use `<Content />` in a custom page without markdown, will raise `[Vue warn]: Unknown custom element`, like #1173 #1426

**Reason**: because it not inject any content in `@internal/page-components` while not find markdown file, `Vue.component` of `pageKey` must be `undefined`, then `h(pageKey)` raise this error

**Fix**: judge as `if (Vue.component(pageKey))`, unnecessary to render if no component existed

![image](https://user-images.githubusercontent.com/15135943/61293040-625bd880-a805-11e9-8716-3eb95b50334a.png)


**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of default theme, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

You have tested in the following browsers: (Providing a detailed version will be better.)

- [x] Chrome
- [x] Firefox
- [x] Safari
- [ ] Edge
- [ ] IE

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature
- [ ] Related documents have been updated
- [ ] Related tests have been updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
