### PR TITLE
fix #1708 prioritise vuepress dependencies over cwd node_modules

### DIFF
--- a/packages/@vuepress/core/lib/node/webpack/createBaseConfig.js
+++ b/packages/@vuepress/core/lib/node/webpack/createBaseConfig.js
@@ -310,5 +310,5 @@ function getLastCommitHash () {
 }
 
 function getModulePaths () {
-  return [path.resolve(process.cwd(), 'node_modules')].concat(module.paths)
+  return module.paths.concat([path.resolve(process.cwd(), 'node_modules')])
 }


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

Have webpack prioritise the use of vuepress dependencies over the working directories node_modules.

Fixes #1708

Currently if vuepress is used to generate docs for a project depending on the latest version of css-loader `yarn vuepress dev docs` serves a blank screen.

If `package.json` resembles this:

```
{
  "scripts": {
    "docs:dev": "vuepress dev docs"
  },
  "dependencies": {
    "vuepress": "^1.0.2",
    "css-loader": "^3.1.0"
  }
}
```

vuepress will serve a blank page with the error: 

```
ValidationError: Invalid options object. CSS Loader has been initialised using an options object that does not match the API schema.
 - options has an unknown property 'exportOnlyLocals'. These properties are valid:
```

**What kind of change does this PR introduce?** (check at least one)

- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of default theme, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [X] Yes
- [ ] No

If yes, please describe the impact and migration path for existing applications:

It will be more difficult to overwrite the versions of packages vuepress depends on.

**The PR fulfills these requirements:**

- [X] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

You have tested in the following browsers: (Providing a detailed version will be better.)

- [ ] Chrome
- [X] Firefox
- [ ] Safari
- [ ] Edge
- [ ] IE

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature
- [ ] Related documents have been updated
- [ ] Related tests have been updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**

This will make the instruction on the front page of `https://vuepress.vuejs.org/` more likely to work on an existing project.