### PR TITLE
Resolve vue-eslint-parser from failing on theme-default Algolia component

### DIFF
--- a/packages/@vuepress/theme-default/components/AlgoliaSearchBox.vue
+++ b/packages/@vuepress/theme-default/components/AlgoliaSearchBox.vue
@@ -31,9 +31,12 @@ export default {
     this.initialize(this.options, this.$lang)
   },
   methods: {
-    initialize (userOptions, lang) {
-      const { algoliaOptions = {}} = userOptions
-      docsearch.default(
+    async initialize(userOptions, lang) {
+      const { algoliaOptions = {} } = userOptions;
+      const docsearch = await require('docsearch.js/dist/cdn/docsearch.min.js');
+      await require('docsearch.js/dist/cdn/docsearch.min.css');
+
+      docsearch(
         Object.assign({}, userOptions, {
           inputSelector: '#algolia-search-input',
           // #697 Make docsearch work well at i18n mode.
@@ -41,12 +44,15 @@ export default {
             {
               facetFilters: [`lang:${lang}`].concat(
                 algoliaOptions.facetFilters || []
-              )
+              ),
             },
             algoliaOptions
-          )
+          ),
+          handleSelected: (input, event, suggestion) => {
+            this.$router.push(new URL(suggestion.url).pathname);
+          },
         })
-      )
+      );
     },
 
     update (options, lang) {

--- a/packages/@vuepress/theme-default/components/AlgoliaSearchBox.vue
+++ b/packages/@vuepress/theme-default/components/AlgoliaSearchBox.vue
@@ -12,43 +12,10 @@
 </template>
 
 <script>
+import 'docsearch.js/dist/cdn/docsearch.min.css'
+import * as docsearch from 'docsearch.js/dist/cdn/docsearch.min.js'
 export default {
   props: ['options'],
-
-  mounted () {
-    this.initialize(this.options, this.$lang)
-  },
-
-  methods: {
-    initialize (userOptions, lang) {
-      Promise.all([
-        import(/* webpackChunkName: "docsearch" */ 'docsearch.js/dist/cdn/docsearch.min.js'),
-        import(/* webpackChunkName: "docsearch" */ 'docsearch.js/dist/cdn/docsearch.min.css')
-      ]).then(([docsearch]) => {
-        docsearch = docsearch.default
-        const { algoliaOptions = {}} = userOptions
-        docsearch(Object.assign(
-          {},
-          userOptions,
-          {
-            inputSelector: '#algolia-search-input',
-            // #697 Make docsearch work well at i18n mode.
-            algoliaOptions: Object.assign({
-              'facetFilters': [`lang:${lang}`].concat(algoliaOptions.facetFilters || [])
-            }, algoliaOptions),
-            handleSelected: (input, event, suggestion) => {
-              this.$router.push(new URL(suggestion.url).pathname)
-            }
-          }
-        ))
-      })
-    },
-
-    update (options, lang) {
-      this.$el.innerHTML = '<input id="algolia-search-input" class="search-query">'
-      this.initialize(options, lang)
-    }
-  },
 
   watch: {
     $lang (newValue) {
@@ -57,6 +24,35 @@ export default {
 
     options (newValue) {
       this.update(newValue, this.$lang)
+    }
+  },
+
+  mounted () {
+    this.initialize(this.options, this.$lang)
+  },
+  methods: {
+    initialize (userOptions, lang) {
+      const { algoliaOptions = {}} = userOptions
+      docsearch.default(
+        Object.assign({}, userOptions, {
+          inputSelector: '#algolia-search-input',
+          // #697 Make docsearch work well at i18n mode.
+          algoliaOptions: Object.assign(
+            {
+              facetFilters: [`lang:${lang}`].concat(
+                algoliaOptions.facetFilters || []
+              )
+            },
+            algoliaOptions
+          )
+        })
+      )
+    },
+
+    update (options, lang) {
+      this.$el.innerHTML
+        = '<input id="algolia-search-input" class="search-query">'
+      this.initialize(options, lang)
     }
   }
 }

--- a/packages/@vuepress/theme-default/components/AlgoliaSearchBox.vue
+++ b/packages/@vuepress/theme-default/components/AlgoliaSearchBox.vue
@@ -12,8 +12,6 @@
 </template>
 
 <script>
-import 'docsearch.js/dist/cdn/docsearch.min.css'
-import * as docsearch from 'docsearch.js/dist/cdn/docsearch.min.js'
 export default {
   props: ['options'],
 


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of default theme, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

You have tested in the following browsers: (Providing a detailed version will be better.)

- [ ] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge
- [ ] IE

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature
- [ ] Related documents have been updated
- [ ] Related tests have been updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
See: https://github.com/mysticatea/vue-eslint-parser/issues/52
See: https://github.com/AtomLinter/linter-eslint/issues/462