### PR TITLE
fix($core): do not transpile core packages' dependencies

### DIFF
--- a/packages/@vuepress/core/lib/node/webpack/createBaseConfig.js
+++ b/packages/@vuepress/core/lib/node/webpack/createBaseConfig.js
@@ -145,7 +145,7 @@ module.exports = function createBaseConfig (context, isServer) {
             return false
           }
           // transpile all core files
-          if (/(@vuepress|vuepress-)\/.*\.js$/.test(filePath)) {
+          if (/(@vuepress|vuepress-)\/^((?!node_modules).)*\.js$/.test(filePath)) {
             return false
           }
           // Don't transpile node_modules


### PR DESCRIPTION
**Summary**

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of default theme, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

You have tested in the following browsers: (Providing a detailed version will be better.)

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
- [ ] IE

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature
- [ ] Related documents have been updated
- [ ] Related tests have been updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**

Didn't have the time to get a minimal reproduction, but here's the error log I've got after upgrading to vuepress 1.0.3: https://app.netlify.com/sites/vue-cli/deploys/5d51074c57e52800094f95af
Seems it's trying to transpile the core-js package and failed.
The change was added in https://github.com/vuejs/vuepress/pull/1685 and was trying to fix https://github.com/vuejs/vuepress/issues/1623. But I think adding the entry files of core plugins is enough to ensure babel's polyfill detection to work, so I excluded the nested `node_modules` directory in the path pattern.