### PR TITLE
feat($shared-utils): remove leading slash of regularPath when getting permalink

### DIFF
--- a/packages/@vuepress/shared-utils/src/getPermalink.ts
+++ b/packages/@vuepress/shared-utils/src/getPermalink.ts
@@ -9,6 +9,9 @@ interface PermalinkOption {
   localePath: string;
 }
 
+function removeLeadingSlash (path: string) {
+  return path.replace(/^\//, '')
+}
 // e.g.
 // filename: docs/_posts/evan you.md
 // content: # yyx 990803
@@ -39,8 +42,7 @@ export = function getPermalink ({
   const month = iMonth < 10 ? `0${iMonth}` : iMonth
   const day = iDay < 10 ? `0${iDay}` : iDay
 
-  // Remove leading slash
-  pattern = pattern.replace(/^\//, '')
+  pattern = removeLeadingSlash(pattern)
 
   const link =
     localePath +
@@ -53,7 +55,7 @@ export = function getPermalink ({
       .replace(/:minutes/, String(minutes))
       .replace(/:seconds/, String(seconds))
       .replace(/:slug/, slug)
-      .replace(/:regular/, regularPath)
+      .replace(/:regular/, removeLeadingSlash(regularPath))
 
   return ensureLeadingSlash(ensureEndingSlash(link))
 }


### PR DESCRIPTION


<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

relevant to #1783

 `:regular` is different with all the other template variables(only `:regular` can't go before a slash).

Besides, I found VuePress can't work fine if someone config like below(although It‘s a meaningless config), and this PR will also solve this problem:
```
module.exports = {
  permalink: ":regular"
};
```

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of default theme, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

You have tested in the following browsers: (Providing a detailed version will be better.)

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
- [ ] IE

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature
- [ ] Related documents have been updated
- [ ] Related tests have been updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
