### PR TITLE
docs: Fix typo in  permalinks.md fix #1813

### DIFF
--- a/packages/docs/docs/guide/permalinks.md
+++ b/packages/docs/docs/guide/permalinks.md
@@ -33,7 +33,7 @@ We have seen the shadow of the blog. Let’s continue to look down.
 
 ## Permalinks
 
-A permalink is a URL that is intended to remain unchanged for a long time, yielding a hyperlink that is less susceptible to link root<sup>[1][1]</sup>. VuePress supports a flexible way to build permalinks, allowing you to use template variables.
+A permalink is a URL that is intended to remain unchanged for a long time, yielding a hyperlink that is less susceptible to link rot<sup>[1][1]</sup>. VuePress supports a flexible way to build permalinks, allowing you to use template variables.
 
 The default permalink is `/:regular`.
 


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**
Fixes a typo in the permalinks section of the guide.  Changes "link root" to "link rot".  The Wikipedia link next to the phrase goes to the "link rot" page.

Fixes #1813 

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [x] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of default theme, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

You have tested in the following browsers: (Providing a detailed version will be better.)

- [ ] Chrome
- [ ] Firefox
- [x] Safari
- [ ] Edge
- [ ] IE

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature
- [ ] Related documents have been updated
- [ ] Related tests have been updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
