### PR TITLE
fix: Bubble toggleSidebar event to parent

### DIFF
--- a/packages/@vuepress/theme-default/layouts/Layout.vue
+++ b/packages/@vuepress/theme-default/layouts/Layout.vue
@@ -120,6 +120,7 @@ export default {
 
   methods: {
     toggleSidebar (to) {
+      this.$emit("toggle-sidebar", this.isSidebarOpen)
       this.isSidebarOpen = typeof to === 'boolean' ? to : !this.isSidebarOpen
     },
 


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**
The `toggleSidebar` event was not being propagated up from the NavBar component. This PR emits that event up to parent elements, so applications have access to the state of whether the side bar is open.

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [X] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of default theme, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

You have tested in the following browsers: (Providing a detailed version will be better.)

- [X] Chrome
- [X] Firefox
- [X] Safari
- [X] Edge
- [X] IE

If adding a **new feature**, the PR's description includes:

- [X] A convincing reason for adding this feature
- [ ] Related documents have been updated
- [ ] Related tests have been updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
