### PR TITLE
refactor($core): stop watching unnecessary events

### DIFF
--- a/packages/@vuepress/core/lib/node/dev/index.js
+++ b/packages/@vuepress/core/lib/node/dev/index.js
@@ -76,8 +76,6 @@ module.exports = class DevProcess extends EventEmitter {
     })
     this.pagesWatcher.on('add', target => this.handleUpdate('add', target))
     this.pagesWatcher.on('unlink', target => this.handleUpdate('unlink', target))
-    this.pagesWatcher.on('addDir', target => this.handleUpdate('addDir', target))
-    this.pagesWatcher.on('unlinkDir', target => this.handleUpdate('unlinkDir', target))
   }
 
   /**


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**
```js
    this.pagesWatcher = chokidar.watch([
      '**/*.md',
      '.vuepress/components/**/*.vue'
    ], {
      cwd: this.context.sourceDir,
      ignored: ['.vuepress/**/*.md', 'node_modules'],
      ignoreInitial: true
    })
```
Because the glob patterns end with`*.md` and `*.vue`, `addDir` and `unlinkDir` will never be triggered, right?

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [x] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of default theme, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

You have tested in the following browsers: (Providing a detailed version will be better.)

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
- [ ] IE

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature
- [ ] Related documents have been updated
- [ ] Related tests have been updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
