### PR TITLE
feat($plugin-search): Add support for search hotkeys

### DIFF
--- a/packages/@vuepress/plugin-search/SearchBox.vue
+++ b/packages/@vuepress/plugin-search/SearchBox.vue
@@ -37,7 +37,7 @@
 </template>
 
 <script>
-/* global SEARCH_MAX_SUGGESTIONS, SEARCH_PATHS */
+/* global SEARCH_MAX_SUGGESTIONS, SEARCH_PATHS, SEARCH_HOTKEYS */
 export default {
   data () {
     return {

--- a/packages/@vuepress/plugin-search/SearchBox.vue
+++ b/packages/@vuepress/plugin-search/SearchBox.vue
@@ -51,12 +51,11 @@ export default {
 
   mounted () {
     this.placeholder = this.$site.themeConfig.searchPlaceholder || ''
-    document.addEventListener('keydown', event => {
-      if (event.srcElement === document.body && SEARCH_HOTKEYS.includes(event.key)) {
-        this.$refs.input.focus()
-        event.preventDefault()
-      }
-    })
+    document.addEventListener('keydown', this.onHotkey)
+  },
+
+  beforeDestroy () {
+    document.removeEventListener('keydown', this.onHotkey)
   },
 
   computed: {
@@ -78,7 +77,8 @@ export default {
       const max = SEARCH_MAX_SUGGESTIONS
       const localePath = this.$localePath
       const matches = item => (
-        item.title
+        item
+        && item.title
         && item.title.toLowerCase().indexOf(query) > -1
       )
       const res = []
@@ -142,6 +142,13 @@ export default {
       return searchPaths.filter(path => {
         return page.path.match(path)
       }).length > 0
+    }, 
+
+    onHotkey (event) {
+      if (event.srcElement === document.body && SEARCH_HOTKEYS.includes(event.key)) {
+        this.$refs.input.focus()
+        event.preventDefault()
+      }
     },
 
     onUp () {

--- a/packages/@vuepress/plugin-search/SearchBox.vue
+++ b/packages/@vuepress/plugin-search/SearchBox.vue
@@ -142,7 +142,7 @@ export default {
       return searchPaths.filter(path => {
         return page.path.match(path)
       }).length > 0
-    }, 
+    },
 
     onHotkey (event) {
       if (event.srcElement === document.body && SEARCH_HOTKEYS.includes(event.key)) {

--- a/packages/@vuepress/plugin-search/SearchBox.vue
+++ b/packages/@vuepress/plugin-search/SearchBox.vue
@@ -12,6 +12,7 @@
       @keyup.enter="go(focusIndex)"
       @keyup.up="onUp"
       @keyup.down="onDown"
+      ref="input"
     >
     <ul
       class="suggestions"
@@ -44,6 +45,15 @@ export default {
       focused: false,
       focusIndex: 0
     }
+  },
+
+  created () {
+    document.addEventListener('keydown', event => {
+      if (event.srcElement === document.body && SEARCH_HOTKEYS.includes(event.key)) {
+        this.$refs.input.focus()
+        event.preventDefault()
+      }
+    })
   },
 
   computed: {

--- a/packages/@vuepress/plugin-search/SearchBox.vue
+++ b/packages/@vuepress/plugin-search/SearchBox.vue
@@ -47,7 +47,7 @@ export default {
     }
   },
 
-  created () {
+  mounted () {
     document.addEventListener('keydown', event => {
       if (event.srcElement === document.body && SEARCH_HOTKEYS.includes(event.key)) {
         this.$refs.input.focus()

--- a/packages/@vuepress/plugin-search/index.js
+++ b/packages/@vuepress/plugin-search/index.js
@@ -8,6 +8,7 @@ module.exports = (options) => ({
 
   define: {
     SEARCH_MAX_SUGGESTIONS: options.searchMaxSuggestions || 5,
-    SEARCH_PATHS: options.test || null
+    SEARCH_PATHS: options.test || null,
+    SEARCH_HOTKEYS: options.searchHotkeys || ['s', '/']
   }
 })

--- a/packages/docs/docs/plugin/official/plugin-search.md
+++ b/packages/docs/docs/plugin/official/plugin-search.md
@@ -95,6 +95,13 @@ You can set up searchable paths with `test` as:
 
 Otherwise,  the default search will return duplicates, once you can have similar content between folders `/master/`, `/1.0/` and `/2.0/`.
 
+### searchHotkeys
+
+- Type: `Array<string>`
+- Default: `['s', '/']`
+
+Configure the hotkeys which when pressed will focus the search box. Set to an empty array to disable this feature.
+
 ## Tips
 
 ### Tweak the default colors.


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

Adds hotkey to focus SearchBox component with configurable keys, defaulting to `s` and `/`.

This makes it much easier to switch to the docs and focus the searchbox when using documentation in tandem with programming. Sites like [docs.rs](https://docs.rs/) and even GitHub itself support this behavior. 

Fixes #624

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**The PR fulfills these requirements:**

- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

You have tested in the following browsers: (Providing a detailed version will be better.)

- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge
- [ ] IE

If adding a **new feature**, the PR's description includes:

- [x] A convincing reason for adding this feature
- [x] Related documents have been updated
- [ ] Related tests have been updated