### PR TITLE
fix($shared-utils): Replace diacritics with String.normalize

### DIFF
--- a/packages/@vuepress/shared-utils/__tests__/slugify.spec.ts
+++ b/packages/@vuepress/shared-utils/__tests__/slugify.spec.ts
@@ -1,0 +1,30 @@
+import slugify from '../src/slugify'
+
+describe('slugify', () => {
+  test('should slugify', () => {
+    const asserts: Record<string, string> = {
+      'Привет': 'привет',
+      'Лед üäöß': 'лед-uaoß',
+      'hangul 가': 'hangul-가',
+      'ع': 'ع',
+      'ǆℍΩ': 'dzhω',
+      'ｶi⁹': 'カi9',
+      // ㌀ -> アパート'
+      '㌀': decodeURIComponent('%E3%82%A2%E3%83%8F%E3%82%9A%E3%83%BC%E3%83%88'),
+      '¼': '_1⁄4',
+      'ǆℍΩｶi⁹¼': 'dzhωカi91⁄4',
+      'Iлｔèｒｎåｔïｏｎɑｌíƶａｔï߀ԉ': 'iлternationɑliƶati߀ԉ',
+      'Båｃòл íｐѕùｍ ðｏɭ߀ｒ ѕïｔ ａϻèｔ âùþê ａԉᏧ߀üïｌɭê ƃëéｆ ｃｕｌρá ｆïｌèｔ ϻｉǥｎòｎ ｃｕρｉᏧａｔａｔ ｕｔ êлｉｍ ｔòлɢùê.':
+        'bacoл-ipѕum-ðoɭ߀r-ѕit-aϻet-auþe-aԉꮷ߀uilɭe-ƃeef-culρa-filet-ϻiǥnon-cuρiꮷatat-ut-eлim-toлɢue',
+      'ᴎᴑᴅᴇȷʂ': 'ᴎᴑᴅᴇȷʂ',
+      'hambúrguer': 'hamburguer',
+      'hŒllœ': 'hœllœ',
+      'Fußball': 'fußball',
+      'ABCDEFGHIJKLMNOPQRSTUVWXYZé': 'abcdefghijklmnopqrstuvwxyze'
+    }
+
+    Object.keys(asserts).forEach(input => {
+      expect(slugify(input)).toBe(asserts[input])
+    })
+  })
+})

--- a/packages/@vuepress/shared-utils/package.json
+++ b/packages/@vuepress/shared-utils/package.json
@@ -31,7 +31,6 @@
   },
   "dependencies": {
     "chalk": "^2.3.2",
-    "diacritics": "^1.3.0",
     "escape-html": "^1.0.3",
     "fs-extra": "^7.0.1",
     "globby": "^9.2.0",

--- a/packages/@vuepress/shared-utils/src/slugify.ts
+++ b/packages/@vuepress/shared-utils/src/slugify.ts
@@ -1,14 +1,17 @@
 // string.js slugify drops non ascii chars so we have to
 // use a custom implementation here
-import { remove as removeDiacritics } from 'diacritics'
 
 // eslint-disable-next-line no-control-regex
 const rControl = /[\u0000-\u001f]/g
 const rSpecial = /[\s~`!@#$%^&*()\-_+=[\]{}|\\;:"'“”‘’–—<>,.?/]+/g
+const rCombining = /[\u0300-\u036F]/g
 
 export = function slugify (str: string): string {
-  return removeDiacritics(str)
-  // Remove control characters
+  // Split accented characters into components
+  return str.normalize('NFKD')
+    // Remove accents
+    .replace(rCombining, '')
+    // Remove control characters
     .replace(rControl, '')
     // Replace special characters
     .replace(rSpecial, '-')

--- a/yarn.lock
+++ b/yarn.lock
@@ -5125,10 +5125,6 @@ dezalgo@^1.0.0:
     asap "^2.0.0"
     wrappy "1"
 
-diacritics@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/diacritics/-/diacritics-1.3.0.tgz#3efa87323ebb863e6696cebb0082d48ff3d6f7a1"
-
 didyoumean@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/didyoumean/-/didyoumean-1.2.1.tgz#e92edfdada6537d484d73c0172fd1eba0c4976ff"


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

fix #1815

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of default theme, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [x] Yes (Possibly?)
- [ ] No

If yes, please describe the impact and migration path for existing applications:

The slugs in the existing URL's will change, so the external links referencing existing pages might break.

**The PR fulfills these requirements:**

- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

You have tested in the following browsers: (Providing a detailed version will be better.)

- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge
- [ ] IE

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature
- [ ] Related documents have been updated
- [ ] Related tests have been updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
So diacritics has some errors in the replacements sets, and it wasn't updated for quite some time. I did a bit of research and looks like using [String.normalize ](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/normalize) might work. 
It is supported by node > 6 but not supported by IE, and the polyfill is huge, but,
@f3ltron, do I understand correctly that slugify util is only ever run on the server side and never in the browser? If so then it's not a problem then.

We can normalize the string (https://www.unicode.org/reports/tr15/#Compatibility_Equivalence_Figure) and in the process it will show accents as separate characters which can be removed with the regex (thanks @glebtv).

I think this will also help if, say, someone typed the links in the .md files manually, and they look the same but internally different - they will reference the same page anyway.