### PR TITLE
feat: add format option for plugin-last-updated[#1854]

### DIFF
--- a/packages/@vuepress/plugin-last-updated/index.js
+++ b/packages/@vuepress/plugin-last-updated/index.js
@@ -12,6 +12,13 @@ module.exports = (options = {}, context) => ({
         : defaultTransformer(timestamp, $lang)
       $page.lastUpdated = lastUpdated
     }
+  },
+  clientDynamicModules () {
+    const { format } = options
+    return {
+      name: 'lastUpdated.js',
+      content: typeof format === 'function' ? `export const format = ${format.toString()}` : ''
+    }
   }
 })
 

--- a/packages/@vuepress/theme-default/components/PageEdit.vue
+++ b/packages/@vuepress/theme-default/components/PageEdit.vue
@@ -13,11 +13,15 @@
 </template>
 <script>
 import { endingSlashRE, outboundRE } from '../util'
+import { format } from '@dynamic/lastUpdated'
 
 export default {
   name: 'PageEdit',
   computed: {
     lastUpdated () {
+      if (format) {
+        return format(this.$page.lastUpdated)
+      }
       return this.$page.lastUpdated
     },
 


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**
feature: [issue#1854](https://github.com/vuejs/vuepress/issues/1854)


###### Usage
```js
['@vuepress/last-updated', {
  transformer: (timestamp, lang) => timestamp,
  format: lastUpdated => new Date(lastUpdated)
}]
```

The format function is used to dynamically capture time and format it when a Web page refreshes rather than at build time. So that, the displayed time automatically adapts to the time zone.

And the parameter `lastUpdated` = `transformer(...)` or `defaultTransformer(...)`


**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of default theme, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [x] Yes
- [ ] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

You have tested in the following browsers: (Providing a detailed version will be better.)

- [x] Chrome
- [x] Firefox
- [x] Safari
- [x] Edge
- [x] IE

If adding a **new feature**, the PR's description includes:

- [x] A convincing reason for adding this feature
- [x] Related documents have been updated
- [ ] Related tests have been updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**

Actually, this method is not elegant enough to use dependencies in `format`, which means that u can't use `moment.formNow()`, or you need to write a `formNow` function yourself.