### PR TITLE
fix($theme-default): regression of custom container default title

### DIFF
--- a/packages/@vuepress/theme-default/index.js
+++ b/packages/@vuepress/theme-default/index.js
@@ -24,18 +24,21 @@ module.exports = (options, ctx) => ({
     ['container', {
       type: 'tip',
       defaultTitle: {
+        '/': 'TIP',
         '/zh/': '提示'
       }
     }],
     ['container', {
       type: 'warning',
       defaultTitle: {
+        '/': 'WARNING',
         '/zh/': '注意'
       }
     }],
     ['container', {
       type: 'danger',
       defaultTitle: {
+        '/': 'WARNING',
         '/zh/': '警告'
       }
     }]


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of default theme, please provide the **before/after** screenshot:

**V0**

![image](https://user-images.githubusercontent.com/18205362/65368765-e0aa8000-dc77-11e9-9fc2-5c078462aad2.png)

**Regression**

![image](https://user-images.githubusercontent.com/18205362/65368746-bd7fd080-dc77-11e9-9f7a-85595bb954fe.png)

**After this patch**

![image](https://user-images.githubusercontent.com/18205362/65368752-c96b9280-dc77-11e9-83fb-aa6f0ba60a46.png)


**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

You have tested in the following browsers: (Providing a detailed version will be better.)

- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
- [ ] IE

**Other information:**

This regression was introduced by #1462:
https://github.com/vuejs/vuepress/pull/1462/files#diff-89632cc75524a98d72bf12ae77132560R24-R41