### PR TITLE
fix($theme-default): make dropdown-title's UI consistent with nav-link

### DIFF
--- a/packages/@vuepress/theme-default/components/DropdownLink.vue
+++ b/packages/@vuepress/theme-default/components/DropdownLink.vue
@@ -109,6 +109,11 @@ export default {
   .dropdown-title
     display block
     font-size 0.9rem
+    font-family inherit
+    cursor inherit
+    padding inherit
+    line-height 1.4rem
+    outline:none;
     background transparent
     border none
     font-weight 500
@@ -163,6 +168,11 @@ export default {
   .dropdown-wrapper
     &.open .dropdown-title
       margin-bottom 0.5rem
+    .dropdown-title
+      font-weight 600
+      font-size inherit
+      &:hover
+        color $accentColor
     .nav-dropdown
       transition height .1s ease-out
       overflow hidden

--- a/packages/@vuepress/theme-default/components/DropdownLink.vue
+++ b/packages/@vuepress/theme-default/components/DropdownLink.vue
@@ -113,7 +113,6 @@ export default {
     cursor inherit
     padding inherit
     line-height 1.4rem
-    outline none
     background transparent
     border none
     font-weight 500

--- a/packages/@vuepress/theme-default/components/DropdownLink.vue
+++ b/packages/@vuepress/theme-default/components/DropdownLink.vue
@@ -113,7 +113,7 @@ export default {
     cursor inherit
     padding inherit
     line-height 1.4rem
-    outline:none;
+    outline none
     background transparent
     border none
     font-weight 500


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

  #1837 convert dropdown-title from `a` to `button`, which brings inconsistent ui between nav-link and dropdown-title.(Especially on the phone)

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of default theme, please provide the **before/after** screenshot:

![Capture](https://user-images.githubusercontent.com/27280733/65654668-32725200-e04c-11e9-9405-c571c84f173d.PNG)


**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

You have tested in the following browsers: (Providing a detailed version will be better.)

- [x] Chrome
- [ ] Firefox
- [x] Safari
- [ ] Edge
- [ ] IE

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature
- [ ] Related documents have been updated
- [ ] Related tests have been updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
