### PR TITLE
fix($core): Extract all headers tags instead of just h2, h3

### DIFF
--- a/packages/@vuepress/core/lib/node/Page.js
+++ b/packages/@vuepress/core/lib/node/Page.js
@@ -114,7 +114,7 @@ module.exports = class Page {
         // headers
         const headers = extractHeaders(
           this._strippedContent,
-          ['h2', 'h3'],
+          ['h2', 'h3', 'h4', 'h5', 'h6'],
           markdown
         )
         if (headers.length) {


### PR DESCRIPTION
**Summary**
Addresses #1903

Currently, the headers are hardcoded to only include h2 and h3, this makes it hard/impossible to access any other non h2/h3 headers.

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [x] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

