### PR TITLE
fix($core): `cannot read property 'path' of undefined`

### DIFF
--- a/packages/@vuepress/core/lib/node/theme-api/index.js
+++ b/packages/@vuepress/core/lib/node/theme-api/index.js
@@ -80,8 +80,8 @@ module.exports = class ThemeAPI {
         isInternal: true
       }
       logger.warn(
-        `[vuepress] Cannot resolve Layout.vue file in \n ${Layout.path}, `
-          + `fallback to default layout: ${fallbackLayoutPath}`
+        `[vuepress] Cannot resolve Layout.vue file in \n ${layoutDirs.join('\n')}, `
+          + `\n fallback to default layout: ${fallbackLayoutPath}`
       )
     }
     if (!NotFound) {


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

When layout is not present in a theme, the following shows up in console:

```
tip Apply theme vuepress-theme-.vuepress (extends vuepress-theme-vuepress-theme) ...
TypeError: Cannot read property 'path' of undefined
    at ThemeAPI.getLayoutComponentMap (@vuepress\core\lib\node\theme-api\index.js:83:67)
    at ThemeAPI.init (@vuepress\core\lib\node\theme-api\index.js:35:36)
    at new ThemeAPI (@vuepress\core\lib\node\theme-api\index.js:17:10)
    at loadTheme (@vuepress\core\lib\node\loadTheme.js:59:10)
    at App.process (@vuepress\core\lib\node\App.js:100:21)
    at dev (@vuepress\core\lib\index.js:14:13)
    at args (vuepress\lib\util.js:35:12)
    at CAC.cli.command.option.option.option.option.option.option.option.option.option.action (vuepress\lib\registerCoreCommands.js:38:23)
    at CAC.runMatchedCommand (cac\dist\index.js:700:38)
    at CAC.parse (cac\dist\index.js:620:18)
    at CLI (vuepress\lib\util.js:23:7)
    at <anonymous>
    at process._tickCallback (internal/process/next_tick.js:189:7)
```

This PR fixes this issue, by removing a reference to an obvious `undefined` value (`Layout`).

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of default theme, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

You have tested in the following browsers: (Providing a detailed version will be better.)

This issue does not correspond to a browser, it's a node-related problem

- [ ] ~~Chrome~~
- [ ] ~~Firefox~~
- [ ] ~~Safari~~
- [ ] ~~Edge~~
- [ ] ~~IE~~
