### PR TITLE
feat: not clean sidebargroup config

### DIFF
--- a/packages/@vuepress/theme-default/util/index.js
+++ b/packages/@vuepress/theme-default/util/index.js
@@ -233,13 +233,10 @@ function resolveItem (item, pages, base, groupDepth = 1) {
         title: item.title
       })
     }
-    return {
+    return Object.assign(item, {
       type: 'group',
-      path: item.path,
-      title: item.title,
-      sidebarDepth: item.sidebarDepth,
       children: children.map(child => resolveItem(child, pages, base, groupDepth + 1)),
       collapsable: item.collapsable !== false
-    }
+    })
   }
 }


### PR DESCRIPTION
People may contain their personal configuration in `themeConfig.sidebar` , and it is not good to clean their configuarion about slidebar group.

For example, I may want to add icon in sidebar by writing:

```js
   {
      title: 'Vue Cli',
      icon: 'vue',
      children: [
        'cli/',
        'cli/intro',
        'cli/quickDev',
        'cli/create',
        'cli/file'
      ]
    },
    {
      title: 'Vuex',
      icon: 'state',
      children: [
        'vuex/',
        'vuex/demo',

      ]
    },
```

and I don't want the `icon` key lost in compiling

<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of default theme, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

You have tested in the following browsers: (Providing a detailed version will be better.)

- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
- [ ] IE

If adding a **new feature**, the PR's description includes:

- [x] A convincing reason for adding this feature
- [ ] Related documents have been updated
- [ ] Related tests have been updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
