### PR TITLE
fix($theme-default): close dropdown-links when focusout on the last item (close #1948)

### DIFF
--- a/packages/@vuepress/theme-default/components/DropdownLink.vue
+++ b/packages/@vuepress/theme-default/components/DropdownLink.vue
@@ -7,7 +7,7 @@
       class="dropdown-title"
       type="button"
       :aria-label="dropdownAriaLabel"
-      @click="toggle"
+      @click="setOpen(!open)"
     >
       <span class="title">{{ item.text }}</span>
       <span
@@ -39,9 +39,9 @@
             >
               <NavLink
                 @focusout="
-                  isOpenAndLastItemOfArray(childSubItem, subItem.items) &&
-                  isOpenAndLastItemOfArray(subItem, item.items) &&
-                  toggle()
+                  isLastItemOfArray(childSubItem, subItem.items) &&
+                  isLastItemOfArray(subItem, item.items) &&
+                  setOpen(false)
                 "
                 :item="childSubItem"/>
             </li>
@@ -49,7 +49,7 @@
 
           <NavLink
             v-else
-            @focusout="isOpenAndLastItemOfArray(subItem, item.items) && toggle()"
+            @focusout="isLastItemOfArray(subItem, item.items) && setOpen(false)"
             :item="subItem"
           />
         </li>
@@ -86,12 +86,12 @@ export default {
   },
 
   methods: {
-    toggle () {
-      this.open = !this.open
+    setOpen (value) {
+      this.open = value
     },
 
-    isOpenAndLastItemOfArray (item, array) {
-      return this.open && last(array) === item
+    isLastItemOfArray (item, array) {
+      return last(array) === item
     }
   },
 

--- a/packages/@vuepress/theme-default/components/DropdownLink.vue
+++ b/packages/@vuepress/theme-default/components/DropdownLink.vue
@@ -39,8 +39,8 @@
             >
               <NavLink
                 @focusout="
-                  isLastItemOfArray(childSubItem, subItem.items) &&
-                  isLastItemOfArray(subItem, item.items) &&
+                  isOpenAndLastItemOfArray(childSubItem, subItem.items) &&
+                  isOpenAndLastItemOfArray(subItem, item.items) &&
                   toggle()
                 "
                 :item="childSubItem"/>
@@ -49,7 +49,7 @@
 
           <NavLink
             v-else
-            @focusout="isLastItemOfArray(subItem, item.items) && toggle()"
+            @focusout="isOpenAndLastItemOfArray(subItem, item.items) && toggle()"
             :item="subItem"
           />
         </li>
@@ -90,8 +90,8 @@ export default {
       this.open = !this.open
     },
 
-    isLastItemOfArray (item, array) {
-      return last(array) === item
+    isOpenAndLastItemOfArray (item, array) {
+      return this.open && last(array) === item
     }
   },
 


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

Fix #1948 

Logic is a little complicated here. Someone please do test this again.

When people use tab to focusout the last item, the dropdown-links should be closed since the `open` class is surely  active.

When people use mouse to focusout the last item, however, the `open` class may not be active.

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of default theme, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

You have tested in the following browsers: (Providing a detailed version will be better.)

- [x] Chrome
- [x] Firefox
- [ ] Safari
- [x] Edge
- [ ] IE

If adding a **new feature**, the PR's description includes:

- [ ] Related documents have been updated
- [ ] A convincing reason for adding this feature
- [ ] Related tests have been updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
