### PR TITLE
docs: move extractHeader documentation to the right section

### DIFF
--- a/packages/docs/docs/config/README.md
+++ b/packages/docs/docs/config/README.md
@@ -300,6 +300,21 @@ module.exports = {
 This option is also included in [Plugin API](../plugin/option-api.md#extendmarkdown).
 :::
 
+### markdown.extractHeaders
+
+- Type: `Array`
+- Default: `['h2', 'h3']`
+
+While preparing the page, headers are extracted from the Markdown file and stored in `this.$page.headers`. By default, VuePress will extract `h2` and `h3` elements for you. You can override the headers it pulls out in your `markdown` options.
+ 
+ ``` js
+module.exports = {
+  markdown: {
+    extractHeaders: [ 'h2', 'h3', 'h4' ]
+  }
+}
+```
+
 ## Build Pipeline
 
 :::tip Configuring CSS Pre-processors

--- a/packages/docs/docs/config/README.md
+++ b/packages/docs/docs/config/README.md
@@ -307,7 +307,7 @@ This option is also included in [Plugin API](../plugin/option-api.md#extendmarkd
 
 While preparing the page, headers are extracted from the Markdown file and stored in `this.$page.headers`. By default, VuePress will extract `h2` and `h3` elements for you. You can override the headers it pulls out in your `markdown` options.
  
- ``` js
+``` js
 module.exports = {
   markdown: {
     extractHeaders: [ 'h2', 'h3', 'h4' ]

--- a/packages/docs/docs/theme/default-theme-config.md
+++ b/packages/docs/docs/theme/default-theme-config.md
@@ -182,17 +182,6 @@ module.exports = {
 }
 ```
 
-### Extract Headers
- While preparing the page, headers are extracted from the Markdown file and stored in `this.$page.headers`. By default, VuePress will extract `h2` and `h3` elements for you.
- You can override the headers it pulls out in your `markdown` options.
- ``` js
-module.exports = {
-  markdown: {
-    extractHeaders: [ 'h2', 'h3', 'h4' ]
-  }
-}
-```
-
 ### Active Header Links
 
 By default, the nested header links and the hash in the URL are updated as the user scrolls to view the different sections of the page. This behavior can be disabled with the following theme config:

--- a/packages/docs/docs/zh/config/README.md
+++ b/packages/docs/docs/zh/config/README.md
@@ -292,6 +292,21 @@ module.exports = {
 这个选项也被 [Plugin API](../plugin/option-api.md#extendmarkdown) 所支持。
 :::
 
+### markdown.extractHeaders
+
+- 类型: `Array`
+- 默认值: `['h2', 'h3']`
+
+Markdown 文件的 headers (标题 & 小标题) 会在准备阶段被提取出来，并存储在 `this.$page.headers` 中。默认情况下，VuePress 会提取 `h2` 和 `h3` 标题。你可以通过这个选项来修改提取出的标题级别。
+ 
+``` js
+module.exports = {
+  markdown: {
+    extractHeaders: [ 'h2', 'h3', 'h4' ]
+  }
+}
+```
+
 ## 构建流程
 
 ### postcss


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

Move `markdown.extractHeader` documentation in the right section (config).

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [x] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of default theme, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [ ] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

You have tested in the following browsers: (Providing a detailed version will be better.)

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
- [ ] IE

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature
- [ ] Related documents have been updated
- [ ] Related tests have been updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
