### PR TITLE
fix($theme-default): wrong algolia search route with base config

### DIFF
--- a/packages/@vuepress/theme-default/components/AlgoliaSearchBox.vue
+++ b/packages/@vuepress/theme-default/components/AlgoliaSearchBox.vue
@@ -46,7 +46,8 @@ export default {
             }, algoliaOptions),
             handleSelected: (input, event, suggestion) => {
               const { pathname, hash } = new URL(suggestion.url)
-              this.$router.push(`${pathname}${hash}`)
+              const routepath = pathname.replace(this.$site.base, '/')
+              this.$router.push(`${routepath}${hash}`)
             }
           }
         ))


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

Fix #1929 
Fix #1802 

Fix algolia search route is not correct in the case that `$site.base` is not `/`.

For example, in [my project documention](https://www.sigure.xyz/shoeprint-recognition/), I search some keywords, it will route to `https://www.xxx.com/$site.base/$size.base/path/to/page/#hash` rather than `https://www.xxx.com/$site.base/path/to/page/#hash`, `$site.base` is repeat.

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of default theme, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

You have tested in the following browsers: (Providing a detailed version will be better.)

- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
- [ ] IE

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature
- [ ] Related documents have been updated
- [ ] Related tests have been updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
