### PR TITLE
feat($markdown): Support for Rust file extension

### DIFF
--- a/packages/@vuepress/markdown/lib/highlight.js
+++ b/packages/@vuepress/markdown/lib/highlight.js
@@ -23,7 +23,8 @@ function getLangCodeFromExtension (extension) {
     sh: 'bash',
     yml: 'yaml',
     styl: 'stylus',
-    kt: 'kotlin'
+    kt: 'kotlin',
+    rs: 'rust'
   }
 
   return extensionMap[extension] || extension


### PR DESCRIPTION
Currently, code from Rust files is not being highlighted. This can be resolved by mapping the Rust file ending to the name.