### PR TITLE
docs: Remove @next tag in official plugins

### DIFF
--- a/packages/docs/docs/plugin/official/plugin-active-header-links.md
+++ b/packages/docs/docs/plugin/official/plugin-active-header-links.md
@@ -10,8 +10,8 @@ metaTitle: A plugin of automatically activating sidebar links when page scrolls 
 ## Install
 
 ```bash
-yarn add -D @vuepress/plugin-active-header-links@next
-# OR npm install -D @vuepress/plugin-active-header-links@next
+yarn add -D @vuepress/plugin-active-header-links
+# OR npm install -D @vuepress/plugin-active-header-links
 ```
 
 ## Usage

--- a/packages/docs/docs/plugin/official/plugin-back-to-top.md
+++ b/packages/docs/docs/plugin/official/plugin-back-to-top.md
@@ -10,8 +10,8 @@ metaTitle: Back-To-Top Plugin | VuePress
 ## Install
 
 ```bash
-yarn add -D @vuepress/plugin-back-to-top@next
-# OR npm install -D @vuepress/plugin-back-to-top@next
+yarn add -D @vuepress/plugin-back-to-top
+# OR npm install -D @vuepress/plugin-back-to-top
 ```
 
 ## Usage

--- a/packages/docs/docs/plugin/official/plugin-medium-zoom.md
+++ b/packages/docs/docs/plugin/official/plugin-medium-zoom.md
@@ -10,8 +10,8 @@ metaTitle: Medium-Zoom Plugin | VuePress
 ## Install
 
 ```bash
-yarn add -D @vuepress/plugin-medium-zoom@next
-# OR npm install -D @vuepress/plugin-medium-zoom@next
+yarn add -D @vuepress/plugin-medium-zoom
+# OR npm install -D @vuepress/plugin-medium-zoom
 ```
 
 ## Usage

--- a/packages/docs/docs/plugin/official/plugin-nprogress.md
+++ b/packages/docs/docs/plugin/official/plugin-nprogress.md
@@ -10,8 +10,8 @@ metaTitle: Nprogress Plugin | VuePress
 ## Install
 
 ```bash
-yarn add -D @vuepress/plugin-nprogress@next
-# OR npm install -D @vuepress/plugin-nprogress@next
+yarn add -D @vuepress/plugin-nprogress
+# OR npm install -D @vuepress/plugin-nprogress
 ```
 
 ## Usage

--- a/packages/docs/docs/plugin/official/plugin-pwa.md
+++ b/packages/docs/docs/plugin/official/plugin-pwa.md
@@ -10,8 +10,8 @@ metaTitle: PWA Plugin | VuePress
 ## Install
 
 ```bash
-yarn add -D @vuepress/plugin-pwa@next
-# OR npm install -D @vuepress/plugin-pwa@next
+yarn add -D @vuepress/plugin-pwa
+# OR npm install -D @vuepress/plugin-pwa
 ```
 
 ## Usage

--- a/packages/docs/docs/plugin/official/plugin-register-components.md
+++ b/packages/docs/docs/plugin/official/plugin-register-components.md
@@ -10,8 +10,8 @@ metaTitle: Register Components Plugin | VuePress
 ## Install
 
 ```bash
-yarn add -D @vuepress/plugin-register-components@next
-# OR npm install -D @vuepress/plugin-register-components@next
+yarn add -D @vuepress/plugin-register-components
+# OR npm install -D @vuepress/plugin-register-components
 ```
 
 ## Usage

--- a/packages/docs/docs/plugin/official/plugin-search.md
+++ b/packages/docs/docs/plugin/official/plugin-search.md
@@ -10,8 +10,8 @@ metaTitle: Search Plugin | VuePress
 ## Install
 
 ```bash
-yarn add -D @vuepress/plugin-search@next
-# OR npm install -D @vuepress/plugin-search@next
+yarn add -D @vuepress/plugin-search
+# OR npm install -D @vuepress/plugin-search
 ```
 
 ::: tip

--- a/packages/docs/docs/zh/plugin/official/plugin-active-header-links.md
+++ b/packages/docs/docs/zh/plugin/official/plugin-active-header-links.md
@@ -10,8 +10,8 @@ metaTitle: 页面滚动时自动激活侧边栏链接的插件 | VuePress
 ## 安装
 
 ```bash
-yarn add -D @vuepress/plugin-active-header-links@next
-# OR npm install -D @vuepress/plugin-active-header-links@next
+yarn add -D @vuepress/plugin-active-header-links
+# OR npm install -D @vuepress/plugin-active-header-links
 ```
 
 ## 使用

--- a/packages/docs/docs/zh/plugin/official/plugin-back-to-top.md
+++ b/packages/docs/docs/zh/plugin/official/plugin-back-to-top.md
@@ -10,8 +10,8 @@ metaTitle: Back-To-Top 插件 | VuePress
 ## 安装
 
 ```bash
-yarn add -D @vuepress/plugin-back-to-top@next
-# OR npm install -D @vuepress/plugin-back-to-top@next
+yarn add -D @vuepress/plugin-back-to-top
+# OR npm install -D @vuepress/plugin-back-to-top
 ```
 
 ## 使用

--- a/packages/docs/docs/zh/plugin/official/plugin-medium-zoom.md
+++ b/packages/docs/docs/zh/plugin/official/plugin-medium-zoom.md
@@ -10,8 +10,8 @@ metaTitle: Medium-Zoom 插件 | VuePress
 ## 安装
 
 ```bash
-yarn add -D @vuepress/plugin-medium-zoom@next
-# OR npm install -D @vuepress/plugin-medium-zoom@next
+yarn add -D @vuepress/plugin-medium-zoom
+# OR npm install -D @vuepress/plugin-medium-zoom
 ```
 
 ## 使用

--- a/packages/docs/docs/zh/plugin/official/plugin-nprogress.md
+++ b/packages/docs/docs/zh/plugin/official/plugin-nprogress.md
@@ -10,8 +10,8 @@ metaTitle: Nprogress 插件 | VuePress
 ## 安装
 
 ```bash
-yarn add -D @vuepress/plugin-nprogress@next
-# 或者 npm install -D @vuepress/plugin-nprogress@next
+yarn add -D @vuepress/plugin-nprogress
+# 或者 npm install -D @vuepress/plugin-nprogress
 ```
 
 ## 使用

--- a/packages/docs/docs/zh/plugin/official/plugin-pwa.md
+++ b/packages/docs/docs/zh/plugin/official/plugin-pwa.md
@@ -10,8 +10,8 @@ metaTitle: PWA 插件 | VuePress
 ## 安装
 
 ```bash
-yarn add -D @vuepress/plugin-pwa@next
-# OR npm install -D @vuepress/plugin-pwa@next
+yarn add -D @vuepress/plugin-pwa
+# OR npm install -D @vuepress/plugin-pwa
 ```
 
 ## 使用

--- a/packages/docs/docs/zh/plugin/official/plugin-register-components.md
+++ b/packages/docs/docs/zh/plugin/official/plugin-register-components.md
@@ -10,8 +10,8 @@ metaTitle: 注册组件的插件 | VuePress
 ## 安装
 
 ```bash
-yarn add -D @vuepress/plugin-register-components@next
-# OR npm install -D @vuepress/plugin-register-components@next
+yarn add -D @vuepress/plugin-register-components
+# OR npm install -D @vuepress/plugin-register-components
 ```
 
 ## 使用

--- a/packages/docs/docs/zh/plugin/official/plugin-search.md
+++ b/packages/docs/docs/zh/plugin/official/plugin-search.md
@@ -10,8 +10,8 @@ metaTitle: Search 插件 | VuePress
 ## 安装
 
 ```bash
-yarn add -D @vuepress/plugin-search@next
-# OR npm install -D @vuepress/plugin-search@next
+yarn add -D @vuepress/plugin-search
+# OR npm install -D @vuepress/plugin-search
 ```
 
 ::: tip


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

Official plugins install with `@next` tag stop to get the latest version

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [x] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of default theme, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

You have tested in the following browsers: (Providing a detailed version will be better.)

- [ ] Chrome
- [ ] Firefox
- [x] Safari
- [ ] Edge
- [ ] IE

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature
- [ ] Related documents have been updated
- [ ] Related tests have been updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
