### PR TITLE
fix($core): isProd is undefined in ready hook

### DIFF
--- a/packages/@vuepress/core/lib/index.js
+++ b/packages/@vuepress/core/lib/index.js
@@ -11,12 +11,14 @@ function createApp (options) {
 
 async function dev (options) {
   const app = createApp(options)
+  app.isProd = false
   await app.process()
   return app.dev()
 }
 
 async function build (options) {
   const app = createApp(options)
+  app.isProd = true
   await app.process()
   return app.build()
 }

--- a/packages/@vuepress/core/lib/node/App.js
+++ b/packages/@vuepress/core/lib/node/App.js
@@ -459,7 +459,6 @@ module.exports = class App {
    */
 
   async dev () {
-    this.isProd = false
     this.devProcess = new DevProcess(this)
     await this.devProcess.process()
     const error = await new Promise(resolve => {
@@ -489,7 +488,6 @@ module.exports = class App {
    */
 
   async build () {
-    this.isProd = true
     this.buildProcess = new BuildProcess(this)
     await this.buildProcess.process()
     await this.buildProcess.render()


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of default theme, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**

Currently, we set `isProd` in `app.dev()` and `app.build()`.

https://github.com/vuejs/vuepress/blob/1a930dc22e4298b648dad37fa07e2442cdcb3c10/packages/%40vuepress/core/lib/node/App.js#L491-L497

As `app.process()` runs before `app.dev()` and `app.build()`, we cannot get `isProd` in `app.process()`.

https://github.com/vuejs/vuepress/blob/1a930dc22e4298b648dad37fa07e2442cdcb3c10/packages/%40vuepress/core/lib/index.js#L18-L22

However, `ready()` hook is applied in `app.process()`, in which we may need `isProd`.

https://github.com/vuejs/vuepress/blob/1a930dc22e4298b648dad37fa07e2442cdcb3c10/packages/%40vuepress/core/lib/node/App.js#L118

So this PR fix this issue

