### PR TITLE
fix($plugin-pwa): no global-ui-component when updatePopup is disabled

### DIFF
--- a/packages/@vuepress/plugin-pwa/index.js
+++ b/packages/@vuepress/plugin-pwa/index.js
@@ -3,7 +3,8 @@ const { logger, fs, path } = require('@vuepress/shared-utils')
 module.exports = (options, context) => ({
   ready () {
     options = Object.assign({
-      serviceWorker: true
+      serviceWorker: true,
+      popupComponent: 'SWUpdatePopup'
     }, options)
   },
 
@@ -26,7 +27,7 @@ module.exports = (options, context) => ({
   //   { name: 'SWUpdatePopup', path: path.resolve(__dirname, 'lib/SWUpdatePopup.vue') }
   // ],
 
-  globalUIComponents: options.popupComponent || 'SWUpdatePopup',
+  globalUIComponents: options.updatePopup ? options.popupComponent : undefined,
 
   enhanceAppFiles: path.resolve(__dirname, 'lib/enhanceAppFile.js'),
 


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of default theme, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**Other information:**

Disable `updatePopup` in `config.js`:

```js
['@vuepress/pwa', {
  updatePopup: false
}],
```


### Before

`index.html` that generated by `build`:

```html
<div class="global-ui"><!----><SWUpdatePopup></SWUpdatePopup></div>
```

### After

`index.html` that generated by `build`:

```html
<div class="global-ui"><!----></div>
```

