### PR TITLE
fix: fail to test specific package

### DIFF
--- a/packages/@vuepress/test-utils/lib/createJestRunner.js
+++ b/packages/@vuepress/test-utils/lib/createJestRunner.js
@@ -1,9 +1,15 @@
 const execa = require('execa')
-const rawArgs = process.argv.slice(2)
 
 const usedPorts = []
 
-module.exports = function createJestRunner (jestArgs) {
+/**
+ * Run jest
+ *
+ * @param {array} jestArgs an array of Jest CLI options
+ * @param {array} rawArgs the processed process.argv - contains '--inspect-brk' for debug
+ */
+
+module.exports = function createJestRunner (jestArgs, rawArgs) {
   return async function () {
     const execArgv = getChildProcesExecArgv()
     const args = [...execArgv, ...jestArgs]

--- a/packages/@vuepress/test-utils/lib/createJestRunner.js
+++ b/packages/@vuepress/test-utils/lib/createJestRunner.js
@@ -11,7 +11,7 @@ const usedPorts = []
 
 module.exports = function createJestRunner (jestArgs, rawArgs) {
   return async function () {
-    const execArgv = getChildProcesExecArgv()
+    const execArgv = getChildProcessExecArgv()
     const args = [...execArgv, ...jestArgs]
     console.log(`running node with args: ${args.join(' ')}`)
     args.unshift(...rawArgs, require.resolve('jest-cli/bin/jest'))
@@ -21,7 +21,7 @@ module.exports = function createJestRunner (jestArgs, rawArgs) {
   }
 }
 
-function getChildProcesExecArgv () {
+function getChildProcessExecArgv () {
   const execArgv = process.execArgv.slice(0)
   const inspectArgvIndex = execArgv.findIndex(argv =>
     argv.includes('--inspect-brk')

--- a/packages/@vuepress/test-utils/lib/createJestRunner.js
+++ b/packages/@vuepress/test-utils/lib/createJestRunner.js
@@ -6,15 +6,15 @@ const usedPorts = []
  * Run jest
  *
  * @param {array} jestArgs an array of Jest CLI options
- * @param {array} rawArgs the processed process.argv - contains '--inspect-brk' for debug
+ * @param {array} debug whether start with '--inspect-brk' or not
  */
 
-module.exports = function createJestRunner (jestArgs, rawArgs) {
+module.exports = function createJestRunner (jestArgs, debug) {
   return async function () {
     const execArgv = getChildProcessExecArgv()
-    const args = [...execArgv, ...jestArgs]
+    const args = [require.resolve('jest-cli/bin/jest'), ...execArgv, ...jestArgs]
+    if (debug) args.unshift('--inspect-brk')
     console.log(`running node with args: ${args.join(' ')}`)
-    args.unshift(...rawArgs, require.resolve('jest-cli/bin/jest'))
     await execa('node', args, {
       stdio: 'inherit'
     })

--- a/scripts/test.js
+++ b/scripts/test.js
@@ -8,7 +8,7 @@ const args = minimist(rawArgs)
 let regex
 if (args.p) {
   const packages = (args.p || args.package).split(',').join('|')
-  regex = `.*@vuepress/(${packages}|plugin-(${packages}))/.*\\.spec\\.js$`
+  regex = `.*@vuepress/(${packages}|plugin-(${packages}))/.*\\.spec\\.(js|ts)$`
   const i = rawArgs.indexOf('-p')
   rawArgs.splice(i, 2)
 }
@@ -17,7 +17,7 @@ const jestRunner = createJestRunner([
   '--config', 'scripts/jest.config.js',
   '--runInBand',
   ...(regex ? [regex] : [])
-])
+], rawArgs)
 
 // ensure the basic temp files were generated
 createApp({

--- a/scripts/test.js
+++ b/scripts/test.js
@@ -6,6 +6,8 @@ const rawArgs = process.argv.slice(2)
 const args = minimist(rawArgs)
 
 let regex
+const debug = !!args['inspect-brk']
+
 if (args.p) {
   const packages = (args.p || args.package).split(',').join('|')
   regex = `.*@vuepress/(${packages}|plugin-(${packages}))/.*\\.spec\\.(js|ts)$`
@@ -17,7 +19,7 @@ const jestRunner = createJestRunner([
   '--config', 'scripts/jest.config.js',
   '--runInBand',
   ...(regex ? [regex] : [])
-], rawArgs)
+], debug)
 
 // ensure the basic temp files were generated
 createApp({


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

`yarn test` will run every tests in all workspaces.

When I looked at the source code, I found that there's an option to test a specific package:
```js
// scripts/test.js
if (args.p) {
  const packages = (args.p || args.package).split(',').join('|')
  regex = `.*@vuepress/(${packages}|plugin-(${packages}))/.*\\.spec\\.(js|ts)$`
  const i = rawArgs.indexOf('-p')
  rawArgs.splice(i, 2)
}

const jestRunner = createJestRunner([
  '--config', 'scripts/jest.config.js',
  '--runInBand',
  ...(regex ? [regex] : [])
], rawArgs)
```

But when I ran `yarn test -p core`, it failed with `ReferenceError: core is not defined`.

I tracked down `createJestRunner` and found it is caused by #1404.

The `rawArgs` is supposed to contain `'--inspect-brk'`, but it will also contain`'-p'` and `'core'` if I run `yarn test --inspect-brk -p core` :

```js
// @test-utils/lib/createJestRunner.js
const execa = require('execa')
const rawArgs = process.argv.slice(2)

const usedPorts = []

module.exports = function createJestRunner (jestArgs) {
  return async function () {
    const execArgv = getChildProcesExecArgv()
    const args = [...execArgv, ...jestArgs]
    console.log(`running node with args: ${args.join(' ')}`)
    args.unshift(...rawArgs, require.resolve('jest-cli/bin/jest'))
    await execa('node', args, {
      stdio: 'inherit'
    })
  }
}
```

Since `rawArgs` has been processed properly in `scripts/test.js`:
```js
  const i = rawArgs.indexOf('-p')
  rawArgs.splice(i, 2)
```
 I add a argument - rawArgs to `createJestRunner`. It also make it a bit more reusable.


**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of default theme, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

You have tested in the following browsers: (Providing a detailed version will be better.)

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
- [ ] IE

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature
- [ ] Related documents have been updated
- [ ] Related tests have been updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
