### PR TITLE
feat($core): enable webpackChunkName by page's relativePath

### DIFF
--- a/packages/@vuepress/core/lib/node/internal-plugins/pageComponents.js
+++ b/packages/@vuepress/core/lib/node/internal-plugins/pageComponents.js
@@ -8,7 +8,8 @@ module.exports = (options, ctx) => {
     async clientDynamicModules () {
       const code = `export default {\n${pages
         .filter(({ _filePath }) => _filePath)
-        .map(({ key, _filePath }) => `  ${JSON.stringify(key)}: () => import(${JSON.stringify(_filePath)})`)
+        .map(({ key, _filePath, relativePath }) =>
+          `  ${JSON.stringify(key)}: () => import( /* webpackChunkName: "${relativePath}" */ ${JSON.stringify(_filePath)})`)
         .join(',\n')} \n}`
       return { name: 'page-components.js', content: code, dirname: 'internal' }
     }


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

Let's say I have a file system like this.

```
content
├── api
│   ├── file2.md
│   ├── file3.md
│   ├── graphql
│   │   ├── file2.md
│   │   └── README.md
│   └── README.md
├── biz
│   └── README.md
├── docs
│   ├── README.md
│   └── vuepress.md
└── README.md
```

Then I run `vuepress build content`. 
The compiled js files would be like this.

```
public/assets/js
├── 10.363d8cae.js
├── 11.7710dbf4.js
├── 12.66ce535a.js
├── 13.3647659b.js
├── 14.fabd0995.js
├── 2.5c95f722.js
├── 3.56fcaa42.js
├── 4.0cf3496f.js
├── 5.c330506c.js
├── 6.074a5e20.js
├── 7.3ab68fd8.js
├── 8.e6f560b8.js
├── 9.34ce1547.js
└── app.9a37a5f7.js
```

By this PR, compiled js files would be like this.

```
public/assets/js
├── 11.5e5f62a6.js
├── 12.1f94a0ad.js
├── 13.646efbc6.js
├── 14.fabd0995.js
├── api
│   ├── file2.md.deb96048.js
│   ├── file3.md.07105d65.js
│   ├── graphql
│   │   ├── file2.md.c9042c17.js
│   │   └── README.md.9db6967e.js
│   └── README.md.d0cc31c9.js
├── app.81d2fb6e.js
├── biz
│   └── README.md.6f99271e.js
├── docs
│   ├── README.md.124a1c6c.js
│   └── vuepress.md.89855cbc.js
└── README.md.a4dbd17c.js
```

This has two benefits.

1. This enables route-based access control from reverse proxy. For example, if `/api` route should only be accessed by `admin`, then the proxy can block `/api/*` and `/assets/js/api/*` for others.
2. This is more easy to find compiled output of certain markdown. 

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of default theme, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

You have tested in the following browsers: (Providing a detailed version will be better.)

- [ ] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge
- [ ] IE

If adding a **new feature**, the PR's description includes:

- [x] A convincing reason for adding this feature
- [ ] Related documents have been updated
- [ ] Related tests have been updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**

#2117 was the original motivation.