### PR TITLE
fix($cli): inferUserDocsDirectory ignore all node_modules

### DIFF
--- a/packages/vuepress/lib/handleUnknownCommand.js
+++ b/packages/vuepress/lib/handleUnknownCommand.js
@@ -55,7 +55,7 @@ module.exports = async function (cli, options) {
 async function inferUserDocsDirectory (cwd) {
   const paths = await globby([
     '**/.vuepress/config.js',
-    '!node_modules'
+    '!**/node_modules/**'
   ], {
     cwd,
     dot: true


### PR DESCRIPTION
Ignore node_modules in multi-layer catalogue in inferUserDocsDirectory

<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of default theme, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

You have tested in the following browsers: (Providing a detailed version will be better.)

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
- [ ] IE

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature
- [ ] Related documents have been updated
- [ ] Related tests have been updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
inferUserDocsDirectory There is a pattern to ignore node_modules for globby in inferUserDocsDirectory function in vuepress/lib/handleUnknowCommand.js. But if there is a folder which has node_modules, it don't work. ' !**/node_modules/**'  will work for this case. There is a demo for this case: https://github.com/cuijing1031/globby-demo.git