### PR TITLE
feat($core): Improve VuePress build time

### DIFF
--- a/packages/@vuepress/core/lib/node/Page.js
+++ b/packages/@vuepress/core/lib/node/Page.js
@@ -286,17 +286,15 @@ module.exports = class Page {
    */
 
   async enhance (enhancers) {
-    const enhancerPromises = []
-
-    for (const { name: pluginName, value: enhancer } of enhancers) {
+    const enhancerPromises = enhancers.map(({ value: enhancer, name: pluginName }) => {
       const enhancerResult = enhancer(this)
       const promise = enhancerResult instanceof Promise ? enhancerResult : Promise.resolve(enhancerResult)
 
-      enhancerPromises.push(promise.catch(e => {
+      promise.catch(e => {
         console.log(e)
         return new Error(`[${pluginName}] execute extendPageData failed.`)
-      }))
-    }
+      })
+    })
 
     const results = await Promise.all(enhancerPromises)
     const enhancerError = results.find(result => result instanceof Error)

--- a/packages/@vuepress/core/lib/node/Page.js
+++ b/packages/@vuepress/core/lib/node/Page.js
@@ -290,7 +290,7 @@ module.exports = class Page {
       const enhancerResult = enhancer(this)
       const promise = enhancerResult instanceof Promise ? enhancerResult : Promise.resolve(enhancerResult)
 
-      promise.catch(e => {
+      return promise.catch(e => {
         console.log(e)
         return new Error(`[${pluginName}] execute extendPageData failed.`)
       })

--- a/packages/@vuepress/core/lib/node/Page.js
+++ b/packages/@vuepress/core/lib/node/Page.js
@@ -286,20 +286,17 @@ module.exports = class Page {
    */
 
   async enhance (enhancers) {
-    const enhancerPromises = enhancers.map(({ value: enhancer, name: pluginName }) => {
-      const enhancerResult = enhancer(this)
-      const promise = enhancerResult instanceof Promise ? enhancerResult : Promise.resolve(enhancerResult)
-
-      return promise.catch(e => {
-        console.log(e)
-        return new Error(`[${pluginName}] execute extendPageData failed.`)
-      })
-    })
-
-    const results = await Promise.all(enhancerPromises)
-    const enhancerError = results.find(result => result instanceof Error)
-    if (enhancerError) throw enhancerError
-
-    return results
+    return Promise.all(
+      enhancers.map(
+        async ({ value: enhancer, name: pluginName }) => {
+          try {
+            await enhancer(this)
+          } catch (error) {
+            console.log(error)
+            throw new Error(`[${pluginName}] execute extendPageData failed.`)
+          }
+        }
+      )
+    )
   }
 }

--- a/packages/@vuepress/core/lib/node/Page.js
+++ b/packages/@vuepress/core/lib/node/Page.js
@@ -286,13 +286,17 @@ module.exports = class Page {
    */
 
   async enhance (enhancers) {
+    const enhancerPromises = []
+
     for (const { name: pluginName, value: enhancer } of enhancers) {
       try {
-        await enhancer(this)
+        enhancerPromises.push(enhancer(this))
       } catch (error) {
         console.log(error)
         throw new Error(`[${pluginName}] execute extendPageData failed.`)
       }
     }
+
+    return Promise.all(enhancerPromises)
   }
 }

--- a/packages/@vuepress/core/lib/node/__tests__/prepare/Page.spec.js
+++ b/packages/@vuepress/core/lib/node/__tests__/prepare/Page.spec.js
@@ -111,11 +111,11 @@ describe('Page', () => {
       page = new Page({ path: '/' }, app)
       enhancers = [
         {
-          pluginName: 'foo',
+          name: 'foo',
           value: jest.fn()
         },
         {
-          pluginName: 'foo',
+          name: 'bar',
           value: jest.fn()
         }
       ]
@@ -130,7 +130,7 @@ describe('Page', () => {
 
     test('should loop over sync and async enhancers', async () => {
       const mixedEnhancers = [...enhancers, {
-        pluginName: 'blog',
+        name: 'blog',
         value: jest.fn().mockResolvedValue({})
       }]
       await page.enhance(mixedEnhancers)
@@ -138,13 +138,14 @@ describe('Page', () => {
       return mixedEnhancers.map(enhancer => expect(enhancer.value).toHaveBeenCalled())
     })
 
-    test('should log when enhancing when failing', async () => {
+    test('should log and throw an error when enhancing fails', async () => {
       const error = { errorMessage: 'this is an error message' }
+      const pluginName = 'error-plugin'
 
       await expect(page.enhance([{
-        pluginName: 'error-plugin',
+        name: pluginName,
         value: jest.fn().mockRejectedValue(error)
-      }])).rejects.toThrow()
+      }])).rejects.toThrowError(`[${pluginName}] execute extendPageData failed.`)
 
       expect(console.log).toHaveBeenCalledWith(error)
     })

--- a/packages/@vuepress/core/lib/node/build/index.js
+++ b/packages/@vuepress/core/lib/node/build/index.js
@@ -89,10 +89,12 @@ module.exports = class Build extends EventEmitter {
     // render pages
     logger.wait('Rendering static HTML...')
 
-    const pagePaths = []
+    const pagePathsPromises = []
     for (const page of this.context.pages) {
-      pagePaths.push(await this.renderPage(page))
+      pagePathsPromises.push(this.renderPage(page))
     }
+
+    const pagePaths = await Promise.all(pagePathsPromises)
 
     readline.clearLine(process.stdout, 0)
     readline.cursorTo(process.stdout, 0)
@@ -134,9 +136,6 @@ module.exports = class Build extends EventEmitter {
 
   async renderPage (page) {
     const pagePath = decodeURIComponent(page.path)
-    readline.clearLine(process.stdout, 0)
-    readline.cursorTo(process.stdout, 0)
-    process.stdout.write(`Rendering page: ${pagePath}`)
 
     // #565 Avoid duplicate description meta at SSR.
     const meta = (page.frontmatter && page.frontmatter.meta || []).filter(item => item.name !== 'description')

--- a/packages/@vuepress/core/lib/node/build/index.js
+++ b/packages/@vuepress/core/lib/node/build/index.js
@@ -89,12 +89,9 @@ module.exports = class Build extends EventEmitter {
     // render pages
     logger.wait('Rendering static HTML...')
 
-    const pagePathsPromises = []
-    for (const page of this.context.pages) {
-      pagePathsPromises.push(this.renderPage(page))
-    }
-
-    const pagePaths = await Promise.all(pagePathsPromises)
+    const pagePaths = await Promise.all(
+      this.context.pages.map(page => this.renderPage(page))
+    )
 
     readline.clearLine(process.stdout, 0)
     readline.cursorTo(process.stdout, 0)


### PR DESCRIPTION
**Summary**

These optimisations make sense on projects that contains a huge amount of pages to render. 

Related to #1560 

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [x] Other, please describe:
Performance enhancement

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No


**Steps:**

[Improvement #1](https://github.com/vuejs/vuepress/commit/9dce83575a8e798ee29fa8ddedacfdfbbb3e7ac6) : Render static pages in parallel instead of rendering one page after the other.
[Improvement #2](https://github.com/vuejs/vuepress/pull/2163/commits/cbe1af0b674d209beedb91c7a4692effc3118d5a) : Run extendPageData enhancers in parallel
