### PR TITLE
fix: opencollective-postinstall failure not being ignored on Windows

### DIFF
--- a/packages/vuepress/package.json
+++ b/packages/vuepress/package.json
@@ -23,7 +23,7 @@
     "vuepress": "cli.js"
   },
   "scripts": {
-    "postinstall": "opencollective-postinstall || true"
+    "postinstall": "opencollective-postinstall || exit 0"
   },
   "browserslist": [
     ">1%"


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

The `true` command does not exist on Windows so a failure of the `opencollective-postinstall` command would lead to an unintentional failure of the `postinstall` script.

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of default theme, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

You have tested in the following browsers: (Providing a detailed version will be better.)

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
- [ ] IE

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature
- [ ] Related documents have been updated
- [ ] Related tests have been updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
