### PR TITLE
fix(shared-utils): add toml to shared-utils dependencies

### DIFF
--- a/packages/@vuepress/shared-utils/package.json
+++ b/packages/@vuepress/shared-utils/package.json
@@ -38,6 +38,7 @@
     "gray-matter": "^4.0.1",
     "hash-sum": "^1.0.2",
     "semver": "^6.0.0",
+    "toml": "^3.0.0",
     "upath": "^1.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

`toml` is used in `packages/@vuepress/shared-utils/src/parseFrontmatter.ts` but `@vuepress/shared-utils` does not have `toml` as dependencies. This cause `@vuepress/markdown` not reusable outside vuepress.

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [x] Build-related changes
- [ ] Other, please describe:

If changing the UI of default theme, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No