### PR TITLE
fix($plugin-search): add watch to fix search bar focus

### DIFF
--- a/packages/@vuepress/plugin-search/SearchBox.vue
+++ b/packages/@vuepress/plugin-search/SearchBox.vue
@@ -121,6 +121,12 @@ export default {
     }
   },
 
+  watch: {
+    query: function () {
+      this.focusIndex = 0
+    }
+  },
+
   mounted () {
     this.placeholder = this.$site.themeConfig.searchPlaceholder || ''
     document.addEventListener('keydown', this.onHotkey)


### PR DESCRIPTION
**Summary**

Fix the focus of the default search bar dropdown.

Steps to reproduce the issue I noticed:
- type `to` in the search bar: 5 results are displayed.
- tap 3 times on down arrow key: the 4th result (`Directory Structure`) is now focused.
- then, type `p`. Your search box input is now `top`. But, there is now only one result, **which is not focused**. To get the focus back, you need to tap 3 times on the up arrow key because the `focusIndex` variable is still set on the 4th element.

I had a `watch` on the `query` property to fix this kind of issue. On each change on the search box input, the `focusIndex` is reset at zero.

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**The PR fulfills these requirements:**

You have tested in the following browsers: (Providing a detailed version will be better.)

- [x] Chrome
- [x] Firefox
- [x] Safari
- [ ] Edge
- [ ] IE

**Other information:**

Thanks for your time reviewing my PR :)