### PR TITLE
feat(markdown): snippet partial import

### DIFF
--- a/packages/@vuepress/markdown/__tests__/__snapshots__/snippet.spec.js.snap
+++ b/packages/@vuepress/markdown/__tests__/__snapshots__/snippet.spec.js.snap
@@ -17,6 +17,12 @@ exports[`snippet import snippet 1`] = `
 </code></pre>
 `;
 
+exports[`snippet import snippet with region and highlight 1`] = `
+<pre><code class="language-js{1,3}">function foo () {
+  // ..
+}</code></pre>
+`;
+
 exports[`snippet import snippet with highlight multiple lines 1`] = `
 <div class="highlight-lines">
   <div class="highlighted">&nbsp;</div>
@@ -34,4 +40,17 @@ exports[`snippet import snippet with highlight single line 1`] = `
 </div>export default function () {
 // ..
 }
+`;
+
+exports[`snippet import snippet with indented region 1`] = `
+<pre><code class="language-html">&lt;section&gt;
+  &lt;h1&gt;Hello World&lt;/h1&gt;
+&lt;/section&gt;
+&lt;div&gt;Lorem Ipsum&lt;/div&gt;</code></pre>
+`;
+
+exports[`snippet import snippet with region 1`] = `
+<pre><code class="language-js">function foo () {
+  // ..
+}</code></pre>
 `;

--- a/packages/@vuepress/markdown/__tests__/__snapshots__/snippet.spec.js.snap
+++ b/packages/@vuepress/markdown/__tests__/__snapshots__/snippet.spec.js.snap
@@ -19,7 +19,32 @@ exports[`snippet import snippet 1`] = `
 
 exports[`snippet import snippet with region and highlight 1`] = `
 <pre><code class="language-js{1,3}">function foo () {
-  // ..
+  return ({
+    dest: '../../vuepress',
+    locales: {
+      '/': {
+        lang: 'en-US',
+        title: 'VuePress',
+        description: 'Vue-powered Static Site Generator'
+      },
+      '/zh/': {
+        lang: 'zh-CN',
+        title: 'VuePress',
+        description: 'Vue 驱动的静态网站生成器'
+      }
+    },
+    head: [
+      ['link', { rel: 'icon', href: \`/logo.png\` }],
+      ['link', { rel: 'manifest', href: '/manifest.json' }],
+      ['meta', { name: 'theme-color', content: '#3eaf7c' }],
+      ['meta', { name: 'apple-mobile-web-app-capable', content: 'yes' }],
+      ['meta', { name: 'apple-mobile-web-app-status-bar-style', content: 'black' }],
+      ['link', { rel: 'apple-touch-icon', href: \`/icons/apple-touch-icon-152x152.png\` }],
+      ['link', { rel: 'mask-icon', href: '/icons/safari-pinned-tab.svg', color: '#3eaf7c' }],
+      ['meta', { name: 'msapplication-TileImage', content: '/icons/msapplication-icon-144x144.png' }],
+      ['meta', { name: 'msapplication-TileColor', content: '#000000' }]
+    ]
+  })
 }</code></pre>
 `;
 
@@ -51,6 +76,62 @@ exports[`snippet import snippet with indented region 1`] = `
 
 exports[`snippet import snippet with region 1`] = `
 <pre><code class="language-js">function foo () {
-  // ..
+  return ({
+    dest: '../../vuepress',
+    locales: {
+      '/': {
+        lang: 'en-US',
+        title: 'VuePress',
+        description: 'Vue-powered Static Site Generator'
+      },
+      '/zh/': {
+        lang: 'zh-CN',
+        title: 'VuePress',
+        description: 'Vue 驱动的静态网站生成器'
+      }
+    },
+    head: [
+      ['link', { rel: 'icon', href: \`/logo.png\` }],
+      ['link', { rel: 'manifest', href: '/manifest.json' }],
+      ['meta', { name: 'theme-color', content: '#3eaf7c' }],
+      ['meta', { name: 'apple-mobile-web-app-capable', content: 'yes' }],
+      ['meta', { name: 'apple-mobile-web-app-status-bar-style', content: 'black' }],
+      ['link', { rel: 'apple-touch-icon', href: \`/icons/apple-touch-icon-152x152.png\` }],
+      ['link', { rel: 'mask-icon', href: '/icons/safari-pinned-tab.svg', color: '#3eaf7c' }],
+      ['meta', { name: 'msapplication-TileImage', content: '/icons/msapplication-icon-144x144.png' }],
+      ['meta', { name: 'msapplication-TileColor', content: '#000000' }]
+    ]
+  })
+}</code></pre>
+`;
+
+exports[`snippet import snippet with region and single line highlight > 10 1`]  = `
+<pre><code class="language-js{11}">function foo () {
+  return ({
+    dest: '../../vuepress',
+    locales: {
+      '/': {
+        lang: 'en-US',
+        title: 'VuePress',
+        description: 'Vue-powered Static Site Generator'
+      },
+      '/zh/': {
+        lang: 'zh-CN',
+        title: 'VuePress',
+        description: 'Vue 驱动的静态网站生成器'
+      }
+    },
+    head: [
+      ['link', { rel: 'icon', href: \`/logo.png\` }],
+      ['link', { rel: 'manifest', href: '/manifest.json' }],
+      ['meta', { name: 'theme-color', content: '#3eaf7c' }],
+      ['meta', { name: 'apple-mobile-web-app-capable', content: 'yes' }],
+      ['meta', { name: 'apple-mobile-web-app-status-bar-style', content: 'black' }],
+      ['link', { rel: 'apple-touch-icon', href: \`/icons/apple-touch-icon-152x152.png\` }],
+      ['link', { rel: 'mask-icon', href: '/icons/safari-pinned-tab.svg', color: '#3eaf7c' }],
+      ['meta', { name: 'msapplication-TileImage', content: '/icons/msapplication-icon-144x144.png' }],
+      ['meta', { name: 'msapplication-TileColor', content: '#000000' }]
+    ]
+  })
 }</code></pre>
 `;

--- a/packages/@vuepress/markdown/__tests__/fragments/code-snippet-with-indented-region.md
+++ b/packages/@vuepress/markdown/__tests__/fragments/code-snippet-with-indented-region.md
@@ -1,0 +1,1 @@
+<<< @/packages/@vuepress/markdown/__tests__/fragments/snippet-with-indented-region.html#body

--- a/packages/@vuepress/markdown/__tests__/fragments/code-snippet-with-region-and-highlight.md
+++ b/packages/@vuepress/markdown/__tests__/fragments/code-snippet-with-region-and-highlight.md
@@ -1,0 +1,1 @@
+<<< @/packages/@vuepress/markdown/__tests__/fragments/snippet-with-region.js#snippet{1,3}

--- a/packages/@vuepress/markdown/__tests__/fragments/code-snippet-with-region-and-single-highlight.md
+++ b/packages/@vuepress/markdown/__tests__/fragments/code-snippet-with-region-and-single-highlight.md
@@ -1,0 +1,1 @@
+<<< @/packages/@vuepress/markdown/__tests__/fragments/snippet-with-region.js#snippet{11}

--- a/packages/@vuepress/markdown/__tests__/fragments/code-snippet-with-region.md
+++ b/packages/@vuepress/markdown/__tests__/fragments/code-snippet-with-region.md
@@ -1,0 +1,1 @@
+<<< @/packages/@vuepress/markdown/__tests__/fragments/snippet-with-region.js#snippet

--- a/packages/@vuepress/markdown/__tests__/fragments/snippet-with-indented-region.html
+++ b/packages/@vuepress/markdown/__tests__/fragments/snippet-with-indented-region.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Document</title>
+</head>
+<body>
+  <!-- #region body -->
+  <section>
+    <h1>Hello World</h1>
+  </section>
+  <div>Lorem Ipsum</div>
+  <!-- #endregion body -->
+</body>
+</html>

--- a/packages/@vuepress/markdown/__tests__/fragments/snippet-with-region.js
+++ b/packages/@vuepress/markdown/__tests__/fragments/snippet-with-region.js
@@ -1,0 +1,7 @@
+// #region snippet
+function foo () {
+  // ..
+}
+// #endregion snippet
+
+export default foo

--- a/packages/@vuepress/markdown/__tests__/fragments/snippet-with-region.js
+++ b/packages/@vuepress/markdown/__tests__/fragments/snippet-with-region.js
@@ -1,6 +1,31 @@
 // #region snippet
 function foo () {
-  // ..
+  return ({
+    dest: '../../vuepress',
+    locales: {
+      '/': {
+        lang: 'en-US',
+        title: 'VuePress',
+        description: 'Vue-powered Static Site Generator'
+      },
+      '/zh/': {
+        lang: 'zh-CN',
+        title: 'VuePress',
+        description: 'Vue 驱动的静态网站生成器'
+      }
+    },
+    head: [
+      ['link', { rel: 'icon', href: `/logo.png` }],
+      ['link', { rel: 'manifest', href: '/manifest.json' }],
+      ['meta', { name: 'theme-color', content: '#3eaf7c' }],
+      ['meta', { name: 'apple-mobile-web-app-capable', content: 'yes' }],
+      ['meta', { name: 'apple-mobile-web-app-status-bar-style', content: 'black' }],
+      ['link', { rel: 'apple-touch-icon', href: `/icons/apple-touch-icon-152x152.png` }],
+      ['link', { rel: 'mask-icon', href: '/icons/safari-pinned-tab.svg', color: '#3eaf7c' }],
+      ['meta', { name: 'msapplication-TileImage', content: '/icons/msapplication-icon-144x144.png' }],
+      ['meta', { name: 'msapplication-TileColor', content: '#000000' }]
+    ]
+  })
 }
 // #endregion snippet
 

--- a/packages/@vuepress/markdown/__tests__/snippet.spec.js
+++ b/packages/@vuepress/markdown/__tests__/snippet.spec.js
@@ -30,4 +30,22 @@ describe('snippet', () => {
     const output = mdH.render(input)
     expect(output).toMatchSnapshot()
   })
+
+  test('import snippet with region', () => {
+    const input = getFragment(__dirname, 'code-snippet-with-region.md')
+    const output = md.render(input)
+    expect(output).toMatchSnapshot()
+  })
+
+  test('import snippet with region and highlight', () => {
+    const input = getFragment(__dirname, 'code-snippet-with-region-and-highlight.md')
+    const output = md.render(input)
+    expect(output).toMatchSnapshot()
+  })
+
+  test('import snippet with indented region', () => {
+    const input = getFragment(__dirname, 'code-snippet-with-indented-region.md')
+    const output = md.render(input)
+    expect(output).toMatchSnapshot()
+  })
 })

--- a/packages/@vuepress/markdown/__tests__/snippet.spec.js
+++ b/packages/@vuepress/markdown/__tests__/snippet.spec.js
@@ -43,6 +43,12 @@ describe('snippet', () => {
     expect(output).toMatchSnapshot()
   })
 
+  test('import snippet with region and single line highlight > 10', () => {
+    const input = getFragment(__dirname, 'code-snippet-with-region-and-single-highlight.md')
+    const output = md.render(input)
+    expect(output).toMatchSnapshot()
+  })
+
   test('import snippet with indented region', () => {
     const input = getFragment(__dirname, 'code-snippet-with-indented-region.md')
     const output = md.render(input)

--- a/packages/@vuepress/markdown/lib/snippet.js
+++ b/packages/@vuepress/markdown/lib/snippet.js
@@ -62,7 +62,7 @@ function findRegion (lines, regionName) {
         }
       }
     } else if (testLine(line, regexp, regionName, true)) {
-      return { start, end: lineId }
+      return { start, end: lineId, regexp }
     }
   }
 
@@ -90,7 +90,10 @@ module.exports = function snippet (md, options = {}) {
 
           if (region) {
             content = dedent(
-              lines.slice(region.start, region.end).join('\n')
+              lines
+                .slice(region.start, region.end)
+                .filter(line => !region.regexp.test(line.trim()))
+                .join('\n')
             )
           }
         }

--- a/packages/@vuepress/markdown/lib/snippet.js
+++ b/packages/@vuepress/markdown/lib/snippet.js
@@ -81,7 +81,8 @@ module.exports = function snippet (md, options = {}) {
       if (loader) {
         loader.addDependency(src)
       }
-      if (fs.existsSync(src)) {
+      const isAFile = fs.lstatSync(src).isFile()
+      if (fs.existsSync(src) && isAFile) {
         let content = fs.readFileSync(src, 'utf8')
 
         if (regionName) {
@@ -100,7 +101,7 @@ module.exports = function snippet (md, options = {}) {
 
         token.content = content
       } else {
-        token.content = `Code snippet path not found: ${src}`
+        token.content = isAFile ? `Code snippet path not found: ${src}` : `Invalid code snippet option`
         token.info = ''
         logger.error(token.content)
       }
@@ -136,7 +137,7 @@ module.exports = function snippet (md, options = {}) {
      *
      * captures: ['/path/to/file.extension', 'extension', '#region', '{meta}']
      */
-    const rawPathRegexp = /^(.+(?:\.([a-z]+)))(?:(#[\w-]+))?(?: ?({\d(?:[,-]\d)?}))?$/
+    const rawPathRegexp = /^(.+(?:\.([a-z]+)))(?:(#[\w-]+))?(?: ?({\d+(?:[,-]\d+)?}))?$/
 
     const rawPath = state.src.slice(start, end).trim().replace(/^@/, root).trim()
     const [filename = '', extension = '', region = '', meta = ''] = (rawPathRegexp.exec(rawPath) || []).slice(1)

--- a/packages/@vuepress/markdown/lib/snippet.js
+++ b/packages/@vuepress/markdown/lib/snippet.js
@@ -1,5 +1,74 @@
 const { fs, logger, path } = require('@vuepress/shared-utils')
 
+function dedent (text) {
+  const wRegexp = /^([ \t]*)(.*)\n/gm
+  let match; let minIndentLength = null
+
+  while ((match = wRegexp.exec(text)) !== null) {
+    const [indentation, content] = match.slice(1)
+    if (!content) continue
+
+    const indentLength = indentation.length
+    if (indentLength > 0) {
+      minIndentLength
+        = minIndentLength !== null
+          ? Math.min(minIndentLength, indentLength)
+          : indentLength
+    } else break
+  }
+
+  if (minIndentLength) {
+    text = text.replace(
+      new RegExp(`^[ \t]{${minIndentLength}}(.*)`, 'gm'),
+      '$1'
+    )
+  }
+
+  return text
+}
+
+function testLine (line, regexp, regionName, end = false) {
+  const [full, tag, name] = regexp.exec(line.trim()) || []
+
+  return (
+    full
+    && tag
+    && name === regionName
+    && tag.match(end ? /^[Ee]nd ?[rR]egion$/ : /^[rR]egion$/)
+  )
+}
+
+function findRegion (lines, regionName) {
+  const regionRegexps = [
+    /^\/\/ ?#?((?:end)?region) ([\w*-]+)$/, // javascript, typescript, java
+    /^\/\* ?#((?:end)?region) ([\w*-]+) ?\*\/$/, // css, less, scss
+    /^#pragma ((?:end)?region) ([\w*-]+)$/, // C, C++
+    /^<!-- #?((?:end)?region) ([\w*-]+) -->$/, // HTML, markdown
+    /^#((?:End )Region) ([\w*-]+)$/, // Visual Basic
+    /^::#((?:end)region) ([\w*-]+)$/, // Bat
+    /^# ?((?:end)?region) ([\w*-]+)$/ // C#, PHP, Powershell, Python, perl & misc
+  ]
+
+  let regexp = null
+  let start = -1
+
+  for (const [lineId, line] of lines.entries()) {
+    if (regexp === null) {
+      for (const reg of regionRegexps) {
+        if (testLine(line, reg, regionName)) {
+          start = lineId + 1
+          regexp = reg
+          break
+        }
+      }
+    } else if (testLine(line, regexp, regionName, true)) {
+      return { start, end: lineId }
+    }
+  }
+
+  return null
+}
+
 module.exports = function snippet (md, options = {}) {
   const fence = md.renderer.rules.fence
   const root = options.root || process.cwd()
@@ -7,13 +76,26 @@ module.exports = function snippet (md, options = {}) {
   md.renderer.rules.fence = (...args) => {
     const [tokens, idx, , { loader }] = args
     const token = tokens[idx]
-    const { src } = token
+    const [src, regionName] = token.src ? token.src.split('#') : ['']
     if (src) {
       if (loader) {
         loader.addDependency(src)
       }
       if (fs.existsSync(src)) {
-        token.content = fs.readFileSync(src, 'utf8')
+        let content = fs.readFileSync(src, 'utf8')
+
+        if (regionName) {
+          const lines = content.split(/\r?\n/)
+          const region = findRegion(lines, regionName)
+
+          if (region) {
+            content = dedent(
+              lines.slice(region.start, region.end).join('\n')
+            )
+          }
+        }
+
+        token.content = content
       } else {
         token.content = `Code snippet path not found: ${src}`
         token.info = ''
@@ -44,15 +126,23 @@ module.exports = function snippet (md, options = {}) {
 
     const start = pos + 3
     const end = state.skipSpacesBack(max, pos)
-    const rawPath = state.src.slice(start, end).trim().replace(/^@/, root)
-    const filename = rawPath.split(/{/).shift().trim()
-    const meta = rawPath.replace(filename, '')
+
+    /**
+     * raw path format: "/path/to/file.extension#region {meta}"
+     *    where #region and {meta} are optionnal
+     *
+     * captures: ['/path/to/file.extension', 'extension', '#region', '{meta}']
+     */
+    const rawPathRegexp = /^(.+(?:\.([a-z]+)))(?:(#[\w-]+))?(?: ?({\d(?:[,-]\d)?}))?$/
+
+    const rawPath = state.src.slice(start, end).trim().replace(/^@/, root).trim()
+    const [filename = '', extension = '', region = '', meta = ''] = (rawPathRegexp.exec(rawPath) || []).slice(1)
 
     state.line = startLine + 1
 
     const token = state.push('fence', 'code', 0)
-    token.info = filename.split('.').pop() + meta
-    token.src = path.resolve(filename)
+    token.info = extension + meta
+    token.src = path.resolve(filename) + region
     token.markup = '```'
     token.map = [startLine, startLine + 1]
 

--- a/packages/docs/docs/guide/markdown.md
+++ b/packages/docs/docs/guide/markdown.md
@@ -345,6 +345,29 @@ It also supports [line highlighting](#line-highlighting-in-code-blocks):
 Since the import of the code snippets will be executed before webpack compilation, you can’t use the path alias in webpack. The default value of `@` is `process.cwd()`.
 :::
 
+You can also use a [VS Code region](https://code.visualstudio.com/docs/editor/codebasics#_folding) in order to only include the corresponding part of the code file. You can provide a custom region name after a `#` following the filepath (`snippet` by default).
+
+**Input**
+
+``` md
+<<< @/../@vuepress/markdown/__tests__/fragments/snippet-with-region.js#snippet{1}
+```
+
+**Code file**
+
+<!--lint disable strong-marker-->
+
+<<< @/../@vuepress/markdown/__tests__/fragments/snippet-with-region.js
+
+<!--lint enable strong-marker-->
+
+**Output**
+
+<!--lint disable strong-marker-->
+
+<<< @/../@vuepress/markdown/__tests__/fragments/snippet-with-region.js#snippet{1}
+
+<!--lint enable strong-marker-->
 
 ## Advanced Configuration
 


### PR DESCRIPTION
Only import a portion of a code file delimited by [VS Code custom regions markers](https://code.visualstudio.com/docs/editor/codebasics#_folding), based on the region key you set via a fragment identifier (`#`):

_<project root>/docs/hello-world.md_
```md
# Hello World

<<< @/src/hello-world.js#function-def{1-2}
```

_<project root>/src/hello-world.js_:
```js
// #region function-def
function helloWorld () {
  // ..
}
// #endregion function-def

export default helloWorld
```

## Motivation

Contents presented with Vuepress (documentation, tutorials, etc.) may (often?) be related to some "real" projects. Ensuring the code snippets in the doc and the "real" code is very important for this use case. Yet, it can be difficult, or even impossible, to split each code sample in a dedicated file. Therefore, some misleading code lines may be shown in the code snippet only because the author needs it in the project.

For example, if I want to show a function in the doc, but I need an `export` in order to use this function in my project, I would have to show it in the code snippet:

```js
function foo () {
  // ...
}

export default foo;
```

## Solution

This solution add support for:

- VS Code custom region markers
  -  clearly indicate a region to import
  - **_why:_** a lot of web developers (and therefore, I guess, Vuepress users) use VS Code and should be familiar with this syntax
- fragment identifier (`path#region`)
  - indicate the name of the custom region to import
  - **_why:_** same logic as the one defined in the [URL standard](https://url.spec.whatwg.org/#concept-url-fragment) (see [W3C doc](https://www.w3.org/Addressing/URL/4_2_Fragments.html))

For more details, see the new documentation and tests.

## Compatibility

Does not introduce any breaking change: result stay exactly the same if no fragment identifier is set (no region name is set by default).
Yet, the new syntax isn't backward compatible: adding a fragment identifier to the path will lead to a "cannot find path @/path/file.ext#region" with the current version of Vuepress. 

If you want to use this feature before this PR is merged, you can use [patch-package](https://www.npmjs.com/package/patch-package) as follow: 

1. download [patches.zip](https://github.com/vuejs/vuepress/files/4342820/patches.zip)
1. extract this zip file in your project root (should create `patches/@vuepress+markdown+1.3.1.patch`)
1. add _patch-package_ to your dev dependencies:
    ```
    npm i -D patch-package
    ```
    or
    ```
    yarn add --dev patch-package postinstall-postinstall
    ```
1. add _patch-package_ in your `postinstall` script
    ```
    "scripts": {
    +  "postinstall": "patch-package"
    }
    ```

## Summary

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**The PR fulfills these requirements:**

You have tested in the following browsers: (Providing a detailed version will be better.)

- [x] Chrome 80.0.3987.132 Linux
- [x] Firefox 74 Linux
- [ ] Safari
- [ ] Edge
- [ ] IE

If adding a **new feature**, the PR's description includes:

- [x] A convincing reason for adding this feature
- [x] Related documents have been updated
- [x] Related tests have been updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information**

This feature is already used on a daily basis for a pretty heavy (but private) project, alongside a related Pandoc filter which provides this feature: [pandoc-import-code](https://github.com/noelmace/pandoc-import-code).