### PR TITLE
fix($plugin-pwa): work with register-service-worker 1.7.0 (close #2222)

### DIFF
--- a/packages/@vuepress/plugin-pwa/lib/enhanceAppFile.js
+++ b/packages/@vuepress/plugin-pwa/lib/enhanceAppFile.js
@@ -1,7 +1,6 @@
 /* global SW_BASE_URL, SW_ENABLED, GA_ID, ga, SW_UPDATE_POPUP, SW_POPUP_COMPONENT */
 
 import Vue from 'vue'
-import { register } from 'register-service-worker'
 import SWUpdateEvent from './SWUpdateEvent'
 import event from './event'
 
@@ -10,12 +9,13 @@ if (SW_UPDATE_POPUP && SW_POPUP_COMPONENT === 'SWUpdatePopup') {
   Vue.component('SWUpdatePopup', () => import('./SWUpdatePopup.vue'))
 }
 
-export default ({ router, isServer }) => {
-  // Register service worker
-  router.onReady(() => {
-    if (process.env.NODE_ENV === 'production'
-      && !isServer
-      && SW_ENABLED) {
+export default async ({ router, isServer }) => {
+  if (process.env.NODE_ENV === 'production' && !isServer && SW_ENABLED) {
+    // register-service-worker@1.7.0 references `window` in outer scope, so we have to import it dynamically in client
+    const { register } = await import('register-service-worker')
+
+    // Register service worker
+    router.onReady(() => {
       register(`${SW_BASE_URL}service-worker.js`, {
         registrationOptions: {},
         ready () {
@@ -49,6 +49,6 @@ export default ({ router, isServer }) => {
           }
         }
       })
-    }
-  })
+    })
+  }
 }

--- a/packages/@vuepress/plugin-pwa/package.json
+++ b/packages/@vuepress/plugin-pwa/package.json
@@ -22,7 +22,7 @@
   "main": "index.js",
   "dependencies": {
     "@vuepress/shared-utils": "^1.3.1",
-    "register-service-worker": "^1.5.2",
+    "register-service-worker": "^1.7.0",
     "workbox-build": "^4.3.1"
   },
   "publishConfig": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -11104,9 +11104,10 @@ regexpu-core@^4.6.0:
     unicode-match-property-ecmascript "^1.0.4"
     unicode-match-property-value-ecmascript "^1.1.0"
 
-register-service-worker@^1.5.2:
-  version "1.6.2"
-  resolved "https://registry.yarnpkg.com/register-service-worker/-/register-service-worker-1.6.2.tgz#9297e54c205c371c6e49bfa88f6997e8dd315f4c"
+register-service-worker@^1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/register-service-worker/-/register-service-worker-1.7.0.tgz#b4b60d87a1d117f119bfd24ece073dcdb85dae64"
+  integrity sha512-sJQIxgodrulyN4d+bTkRnroPNMH3i1J4kP7Wm+vLhTP5CdbDSRr5jCeC9sJ6jyL603IZVbMAZ5HcU0hWCbJQQA==
 
 registry-auth-token@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

close #2222

It's caused by https://github.com/yyx990803/register-service-worker/pull/33 , which references `window.addEventListener` in the outer scope.

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of default theme, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

You have tested in the following browsers: (Providing a detailed version will be better.)

- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
- [ ] IE

**Other information:**
