### PR TITLE
fix($theme-default): disabling homepage title invalidate aria-labelledby (fix #2273)

### DIFF
--- a/packages/@vuepress/theme-default/components/Home.vue
+++ b/packages/@vuepress/theme-default/components/Home.vue
@@ -1,7 +1,7 @@
 <template>
   <main
     class="home"
-    aria-labelledby="main-title"
+    :aria-labelledby="data.heroText !== null ? 'main-title' : null"
   >
     <header class="hero">
       <img


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

#2273 

When homepage title is disabled, the `aria-labelledby` point to nothing.

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of default theme, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [ ] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

You have tested in the following browsers: (Providing a detailed version will be better.)

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
- [ ] IE

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature
- [ ] Related documents have been updated
- [ ] Related tests have been updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
