### PR TITLE
docs: fix broken link for globalLayout

### DIFF
--- a/packages/docs/docs/theme/inheritance.md
+++ b/packages/docs/docs/theme/inheritance.md
@@ -35,7 +35,7 @@ module.exports = {
 
 ## Inheritance Strategy
 
-All the capabilities of the parent theme will be `"passed"` to the child theme. For file-level conventions, child theme can override it by creating a file with the same name in the same location. For some theme configuration options, such as [globalLayout](./option-api.md/globallayout), child theme can override it by the same name configuration.
+All the capabilities of the parent theme will be `"passed"` to the child theme. For file-level conventions, child theme can override it by creating a file with the same name in the same location. For some theme configuration options, such as [globalLayout](./option-api.md#globallayout), child theme can override it by the same name configuration.
 
 The [file-level conventions](./writing-a-theme.md#directory-structure) are as follows:
 


### PR DESCRIPTION
Fix broken link for `globalLayout` in theme -> **Inheritance Strategy** section

<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [x] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of default theme, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**Other information:**
