### PR TITLE
fix($theme-default): improve last-updated text color contrast

### DIFF
--- a/packages/@vuepress/theme-default/components/PageEdit.vue
+++ b/packages/@vuepress/theme-default/components/PageEdit.vue
@@ -129,7 +129,7 @@ export default {
       color lighten($textColor, 25%)
     .time
       font-weight 400
-      color #aaa
+      color #767676
 
 @media (max-width: $MQMobile)
   .page-edit


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

On the `.last-updated .time` element, the **color contrast is too low** which raised an accessibility warning in a Lighthouse report.

Here is a minor tweak of the color to fix that.

It won't affect much the end user, but provides:
  - a more accessible website :tada: 
  - a better lighthouse accessibility score by default :ok_hand: 

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [x] Other, please describe:
Style

If changing the UI of default theme, please provide the **before/after** screenshot:

| | Before | After |
|-|-|-|
|Screenshot | ![Screenshot from 2020-04-05 19-21-41](https://user-images.githubusercontent.com/1302282/78505459-f135ca00-7773-11ea-9723-09613499cd4e.png) | ![Screenshot from 2020-04-05 19-22-18](https://user-images.githubusercontent.com/1302282/78505466-fabf3200-7773-11ea-8d0d-3ca60828de43.png) |
| Chrome contrast ratio | ![Screenshot from 2020-04-05 19-23-42](https://user-images.githubusercontent.com/1302282/78505483-04e13080-7774-11ea-86f4-f735b431b78d.png) | ![Screenshot from 2020-04-05 19-23-26](https://user-images.githubusercontent.com/1302282/78505489-0e6a9880-7774-11ea-8bea-d7a4c43fd527.png) |

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

You have tested in the following browsers: (Providing a detailed version will be better.)

- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
- [ ] IE

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature
- [ ] Related documents have been updated
- [ ] Related tests have been updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**

If we want to support a contrast ratio AAA we would need to update the color to at least: `#595959`. But the end result doesn't work as the time seems as black as the text. That's why, going for a contrast ratio AA is sufficient.
