### PR TITLE
docs: Add section about configuration override

### DIFF
--- a/packages/docs/docs/theme/inheritance.md
+++ b/packages/docs/docs/theme/inheritance.md
@@ -104,6 +104,43 @@ module.exports = {
 You shouldn’t need to do this unless you know for sure that disabling plugins in parent themes won’t cause problems.
 :::
 
+## Override Configuration
+
+In the scenario where you want to override your user theme config or you want to change the default values from the parent theme there is an easy way to do so.
+
+In your `theme/index.js`, you can override the `themeConfig` values.
+So let's say your theme is extending the default theme but you want sidebarDepth to be 0 then you would do:
+
+```js
+// theme/index.js
+module.exports = (themeConfig) => {
+  themeConfig.sidebarDepth = 0
+
+  return {
+    extend: "@vuepress/theme-default",
+  }
+}
+```
+
+In case you still want the user to have the possibility to configure it but you want to change the default value (the default theme as a `sidebarDepth` of `1`), here we will change the default to `0`. 
+
+```js
+// theme/index.js
+module.exports = (themeConfig) => {
+  themeConfig.sidebarDepth = themeConfig.sidebarDepth || 0
+
+  return {
+    extend: "@vuepress/theme-default",
+  }
+}
+```
+
+Now, if the user sets `themeConfig: { sidebarDepth: 2 }` in it's `.vuepress/config.js`. The final value will be `2`. If he doesn't define it, then it will now default to `0`.
+
+::: warning
+When overriding `themeConfig` values that are used by the parent theme, be sure that your default value is supported by it.
+:::
+
 ## Override Components
 
 You may want to override the same-name components in the parent theme. By default, when the components in the parent theme use relative paths to reference other components, you will not be able to do this because you cannot edit the code of the parent theme at runtime.


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

Add more information about how to override the parent theme default configuration when extending a theme.

If this get accepted, the Chinese documentation still needs to be updated accordingly.

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [x] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of default theme, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [ ] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

You have tested in the following browsers: (Providing a detailed version will be better.)

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
- [ ] IE

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature
- [ ] Related documents have been updated
- [ ] Related tests have been updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**

Related to #2296 
