### PR TITLE
revert: "fix($theme-default): close dropdown on mouseout (fix #2227)"

### DIFF
--- a/packages/@vuepress/theme-default/components/DropdownLink.vue
+++ b/packages/@vuepress/theme-default/components/DropdownLink.vue
@@ -124,7 +124,6 @@ export default {
     border none
     font-weight 500
     color $textColor
-    pointer-events none
     &:hover
       border-color transparent
     .arrow


### PR DESCRIPTION
Reverts vuejs/vuepress#2303