### PR TITLE
fix($shared-utils): add missing type dependencies

### DIFF
--- a/packages/@vuepress/shared-utils/README.md
+++ b/packages/@vuepress/shared-utils/README.md
@@ -1,3 +1,3 @@
-# @vuepress/shard-utils
+# @vuepress/shared-utils
 
-> shard-utils for VuePress
+> Shared utilities for VuePress

--- a/packages/@vuepress/shared-utils/package.json
+++ b/packages/@vuepress/shared-utils/package.json
@@ -41,7 +41,11 @@
     "upath": "^1.1.0"
   },
   "devDependencies": {
-    "@types/diacritics": "^1.3.1"
+    "@types/diacritics": "^1.3.1",
+    "@types/escape-html": "^0.0.20",
+    "@types/fs-extra": "^5.0.4",
+    "@types/hash-sum": "^1.0.0",
+    "@types/semver": "^6.0.0"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [x] Other, please describe

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**The PR fulfills these requirements:**

- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

You have tested in the following browsers: **N/A**

If adding a **new feature**, the PR's description includes: **N/A**

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**

When using `@vuepress/shared-utils` in an external Typescript project (a VuePress plugin), building with `tsc` produces the following errors:

```
node_modules/@vuepress/shared-utils/types/index.d.ts:29:16 - error TS7016: Could not find a declaration file for module 'fs-extra'. '<package-root>/node_modules/fs-extra/lib/index.js' implicitly has an 'any' type.
  Try `npm install @types/fs-extra` if it exists or add a new declaration (.d.ts) file containing `declare module 'fs-extra';`

29 import fs from 'fs-extra';
                  ~~~~~~~~~~
node_modules/@vuepress/shared-utils/types/index.d.ts:32:18 - error TS7016: Could not find a declaration file for module 'hash-sum'. '<package-root>/node_modules/hash-sum/hash-sum.js' implicitly has an 'any' type.
  Try `npm install @types/hash-sum` if it exists or add a new declaration (.d.ts) file containing `declare module 'hash-sum';`

32 import hash from 'hash-sum';
                    ~~~~~~~~~~
node_modules/@vuepress/shared-utils/types/index.d.ts:33:24 - error TS7016: Could not find a declaration file for module 'escape-html'. '<package-root>/node_modules/escape-html/index.js' implicitly has an 'any' type.
  Try `npm install @types/escape-html` if it exists or add a new declaration (.d.ts) file containing `declare module 'escape-html';`

33 import escapeHtml from 'escape-html';
                          ~~~~~~~~~~~~~
node_modules/@vuepress/shared-utils/types/index.d.ts:34:20 - error TS7016: Could not find a declaration file for module 'semver'. '<package-root>/node_modules/semver/semver.js' implicitly has an 'any' type.
  Try `npm install @types/semver` if it exists or add a new declaration (.d.ts) file containing `declare module 'semver';`

34 import semver from 'semver';
                      ~~~~~~~~
Found 4 errors.
```

The main `package.json` already has the type packages in its `devDependencies`. This PR simply adds the same type packages to the `shared-utils` package.json and resolves the errors above.