### PR TITLE
fix($core): include polyfills correctly (close #1168)

### DIFF
--- a/packages/@vuepress/core/lib/node/webpack/createBaseConfig.js
+++ b/packages/@vuepress/core/lib/node/webpack/createBaseConfig.js
@@ -173,8 +173,7 @@ module.exports = function createBaseConfig (context, isServer) {
             presets: [
               [require.resolve('@vue/babel-preset-app'), {
                 entryFiles: [
-                  path.resolve(__dirname, '../../client/clientEntry.js'),
-                  path.resolve(__dirname, '../../client/serverEntry.js')
+                  path.resolve(__dirname, '../../client', isServer ? 'serverEntry.js' : 'clientEntry.js')
                 ]
               }]
             ]

--- a/packages/@vuepress/core/lib/node/webpack/createBaseConfig.js
+++ b/packages/@vuepress/core/lib/node/webpack/createBaseConfig.js
@@ -137,14 +137,16 @@ module.exports = function createBaseConfig (context, isServer) {
       .rule('js')
         .test(/\.jsx?$/)
         .exclude.add(filePath => {
-          // Always transpile lib directory
+          // transpile lib directory
           if (filePath.startsWith(libDir)) {
             return false
           }
-          // always transpile js in vue files and md files
+
+          // transpile js in vue files and md files
           if (/\.(vue|md)\.js$/.test(filePath)) {
             return false
           }
+
           // transpile all core packages and vuepress related packages.
           // i.e.
           // @vuepress/*
@@ -158,7 +160,7 @@ module.exports = function createBaseConfig (context, isServer) {
             return false
           }
 
-          // Don't transpile node_modules
+          // don't transpile node_modules
           return /node_modules/.test(filePath)
         }).end()
         .use('cache-loader')

--- a/packages/@vuepress/core/lib/node/webpack/createBaseConfig.js
+++ b/packages/@vuepress/core/lib/node/webpack/createBaseConfig.js
@@ -171,7 +171,12 @@ module.exports = function createBaseConfig (context, isServer) {
             // ref: http://babeljs.io/docs/en/config-files
             configFile: false,
             presets: [
-              require.resolve('@vue/babel-preset-app')
+              [require.resolve('@vue/babel-preset-app'), {
+                entryFiles: [
+                  path.resolve(__dirname, '../../client/clientEntry.js'),
+                  path.resolve(__dirname, '../../client/serverEntry.js')
+                ]
+              }]
             ]
           })
   }

--- a/packages/@vuepress/core/lib/node/webpack/createBaseConfig.js
+++ b/packages/@vuepress/core/lib/node/webpack/createBaseConfig.js
@@ -152,6 +152,12 @@ module.exports = function createBaseConfig (context, isServer) {
           if (/(@vuepress[\/\\][^\/\\]*|vuepress-[^\/\\]*)[\/\\](?!node_modules).*\.js$/.test(filePath)) {
             return false
           }
+
+          // transpile @babel/runtime until fix for babel/babel#7597 is released
+          if (filePath.includes(path.join('@babel', 'runtime'))) {
+            return false
+          }
+
           // Don't transpile node_modules
           return /node_modules/.test(filePath)
         }).end()


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of default theme, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

You have tested in the following browsers: (Providing a detailed version will be better.)

- [x] Chrome - 81
- [x] Firefox - 75
- [x] Safari - 13.1
- [x] Edge - 81
- [x] IE - 11

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature
- [ ] Related documents have been updated
- [ ] Related tests have been updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**

This change passes the list of entry files into the options of `@vue/babel-preset-app`.

I spent some time looking at #1168 and this is what I found out:

`@vue/babel-preset-app` invokes `@babel/preset-env` with its `useBuiltIns: 'usage'` option, which means polyfills are only added if the user's code makes use of those language features.

But, `@vue/babel-preset-app` will try to auto-include 4 specific polyfills, if the target env needs them. These polyfills for language features needed by libraries that are usually used with vue (e.g. vuex, vue-router). By default, `@babel/preset-env` with `useBuiltIns: usage` doesn't look at dependencies, so auto-including the polyfills is a way to ensure they're available in a vue app.

The 4 polyfills are:

- `es.array.iterator`
- `es.promise`
- `es.object.assign`
- `es.promise.finally`

In `@vue/babel-preset-app`, there is a private babel plugin called `polyfillsPlugin` which adds the polyfills to the top of the files specified by the "entryFiles" option. Due to the way vuepress currently invokes `@vue/babel-preset-app`, no entry files are specified so the auto-included polyfills never make it into the bundle.