### PR TITLE
fix: allows no rel attribute on external links in the nav

### DIFF
--- a/packages/@vuepress/theme-default/components/NavLink.vue
+++ b/packages/@vuepress/theme-default/components/NavLink.vue
@@ -71,7 +71,7 @@ export default {
       if (this.isNonHttpURI) {
         return null
       }
-      if (!this.item.rel && this.item.rel !== undefined) {
+      if (!this.item.rel && this.item.rel === false) {
         return null
       }
       if (this.item.rel) {

--- a/packages/@vuepress/theme-default/components/NavLink.vue
+++ b/packages/@vuepress/theme-default/components/NavLink.vue
@@ -71,10 +71,13 @@ export default {
       if (this.isNonHttpURI) {
         return null
       }
+      if (!this.item.rel && this.item.rel !== undefined) {
+        return null
+      }
       if (this.item.rel) {
         return this.item.rel
       }
-      return this.isBlankTarget ? 'noopener noreferrer' : ''
+      return this.isBlankTarget ? 'noopener noreferrer' : null
     }
   },
 

--- a/packages/@vuepress/theme-default/components/NavLink.vue
+++ b/packages/@vuepress/theme-default/components/NavLink.vue
@@ -71,7 +71,7 @@ export default {
       if (this.isNonHttpURI) {
         return null
       }
-      if (!this.item.rel && this.item.rel === false) {
+      if (this.item.rel === false) {
         return null
       }
       if (this.item.rel) {

--- a/packages/docs/docs/theme/default-theme-config.md
+++ b/packages/docs/docs/theme/default-theme-config.md
@@ -69,7 +69,7 @@ module.exports = {
 }
 ```
 
-Outbound links automatically get `target="_blank" rel="noopener noreferrer"`. You can offer `target` and `rel` to customize the attributes. Passing a "falsy" value to the `rel` attribute will disable that attribute for a link:
+Outbound links automatically get `target="_blank" rel="noopener noreferrer"`. You can offer `target` and `rel` to customize the attributes. Passing a "falsy" value (that is _not_ `undefined`) to the `rel` attribute will disable that attribute for a link:
 
 ``` js
 // .vuepress/config.js

--- a/packages/docs/docs/theme/default-theme-config.md
+++ b/packages/docs/docs/theme/default-theme-config.md
@@ -69,14 +69,14 @@ module.exports = {
 }
 ```
 
-Outbound links automatically get `target="_blank" rel="noopener noreferrer"`. You can offer `target` and `rel` to customize the attributes:
+Outbound links automatically get `target="_blank" rel="noopener noreferrer"`. You can offer `target` and `rel` to customize the attributes. Passing a "falsy" value to the `rel` attribute will disable that attribute for a link:
 
 ``` js
 // .vuepress/config.js
 module.exports = {
   themeConfig: {
     nav: [
-      { text: 'External', link: 'https://google.com', target:'_self', rel:'' },
+      { text: 'External', link: 'https://google.com', target:'_self', rel:false },
       { text: 'Guide', link: '/guide/', target:'_blank' }
     ]
   }
@@ -353,7 +353,7 @@ You can improve the search result by [setting `tags` in frontmatter](../guide/fr
 
 ```yaml
 ---
-tags: 
+tags:
   - configuration
   - theme
   - indexing

--- a/packages/docs/docs/theme/default-theme-config.md
+++ b/packages/docs/docs/theme/default-theme-config.md
@@ -69,7 +69,7 @@ module.exports = {
 }
 ```
 
-Outbound links automatically get `target="_blank" rel="noopener noreferrer"`. You can offer `target` and `rel` to customize the attributes. Passing a "falsy" value (that is _not_ `undefined`) to the `rel` attribute will disable that attribute for a link:
+Outbound links automatically get `target="_blank" rel="noopener noreferrer"`. You can offer `target` and `rel` to customize the attributes. Setting `rel: false` as will disable the `rel` attribute for a link:
 
 ``` js
 // .vuepress/config.js


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

Currently it's not possible to specify that there should be no `rel` attribute on external nav links to use the default behavior. Setting to an empty string, as [indicated in the documentation](https://v1.vuepress.vuejs.org/theme/default-theme-config.html#navbar-links), is falsy, so you end up in the final ternary, which uses `noopener noreferrer` for external links.

This change allows devs to pass in a falsy, non-`undefined`, value to the `rel` property to have no rel attribute on the link. It also change the fallback of an empty string to `null` since an empty `rel` attribute has no particular meaning, so it's better to have it not there at all.

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [x] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of default theme, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

You have tested in the following browsers: (Providing a detailed version will be better.)

I could not tell from the contributor guide or the package scripts how to build this for linking to a project and testing. I'd be happy to do that with some direction.
- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
- [ ] IE

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature
- [x] Related documents have been updated
- [ ] Related tests have been updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
