### PR TITLE
feat($shared-utils): enhance header parsing

### DIFF
--- a/packages/@vuepress/shared-utils/src/parseHeaders.ts
+++ b/packages/@vuepress/shared-utils/src/parseHeaders.ts
@@ -17,8 +17,8 @@ import parseEmojis from './parseEmojis'
 const removeMarkdownTokens = (str: string): string => String(str)
   .replace(/\[(.*)\]\(.*\)/, '$1')              // []()
   .replace(/(`|\*{1,3}|_)(.*?[^\\])\1/g, '$2')  // `{t}` | *{t}* | **{t}** | ***{t}*** | _{t}_
-  .replace(/ \$\S*?\$ /g, ' ') // ` ${t}$ `
-  .replace(/(\\)(\*|_|`|!|\$)/g, '$2')            // remove escape char '\'
+  .replace(/(^| )\$\S*?\$( |$)/g, '')           // ` ${t}$ `
+  .replace(/(\\)(\*|_|`|!|\$)/g, '$2')          // remove escape char '\'
 
 const trim = (str: string): string => str.trim()
 

--- a/packages/@vuepress/shared-utils/src/parseHeaders.ts
+++ b/packages/@vuepress/shared-utils/src/parseHeaders.ts
@@ -17,7 +17,8 @@ import parseEmojis from './parseEmojis'
 const removeMarkdownTokens = (str: string): string => String(str)
   .replace(/\[(.*)\]\(.*\)/, '$1')              // []()
   .replace(/(`|\*{1,3}|_)(.*?[^\\])\1/g, '$2')  // `{t}` | *{t}* | **{t}** | ***{t}*** | _{t}_
-  .replace(/(\\)(\*|_|`|\!)/g, '$2')            // remove escape char '\'
+  .replace(/ \$\S*?\$ /g, ' ') // ` ${t}$ `
+  .replace(/(\\)(\*|_|`|!|\$)/g, '$2')            // remove escape char '\'
 
 const trim = (str: string): string => str.trim()
 

--- a/packages/@vuepress/shared-utils/src/parseHeaders.ts
+++ b/packages/@vuepress/shared-utils/src/parseHeaders.ts
@@ -17,7 +17,7 @@ import parseEmojis from './parseEmojis'
 const removeMarkdownTokens = (str: string): string => String(str)
   .replace(/(^| )\$\S*?\$( |$)/g, '')           // ` ${t}$ `
   .replace(/\[(.*)\]\(.*\)/, '$1')              // []()
-  .replace(/(`|\*{1,3}|_|^)(.*?[^\\])\1/g, '$2')  // `{t}` | *{t}* | **{t}** | ***{t}*** | _{t}_ | ^{t}^
+  .replace(/(`|\*{1,3}|_|~|\^)(.*?[^\\])\1/g, '$2')  // `{t}` | *{t}* | **{t}** | ***{t}*** | _{t}_ | ^{t}^ | ~{t}~
   .replace(/(\\)(\*|_|`|!|\$)/g, '$2')          // remove escape char '\'
 
 const trim = (str: string): string => str.trim()

--- a/packages/@vuepress/shared-utils/src/parseHeaders.ts
+++ b/packages/@vuepress/shared-utils/src/parseHeaders.ts
@@ -15,9 +15,9 @@ import parseEmojis from './parseEmojis'
 // wrapped by <code>(markdown token: '`') tag.
 
 const removeMarkdownTokens = (str: string): string => String(str)
-  .replace(/\[(.*)\]\(.*\)/, '$1')              // []()
-  .replace(/(`|\*{1,3}|_)(.*?[^\\])\1/g, '$2')  // `{t}` | *{t}* | **{t}** | ***{t}*** | _{t}_
   .replace(/(^| )\$\S*?\$( |$)/g, '')           // ` ${t}$ `
+  .replace(/\[(.*)\]\(.*\)/, '$1')              // []()
+  .replace(/(`|\*{1,3}|_|^)(.*?[^\\])\1/g, '$2')  // `{t}` | *{t}* | **{t}** | ***{t}*** | _{t}_ | ^{t}^
   .replace(/(\\)(\*|_|`|!|\$)/g, '$2')          // remove escape char '\'
 
 const trim = (str: string): string => str.trim()


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of default theme, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

You have tested in the following browsers: (Providing a detailed version will be better.)

- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge
- [ ] IE

If adding a **new feature**, the PR's description includes:

- [x] A convincing reason for adding this feature
- [ ] Related documents have been updated
- [ ] Related tests have been updated

Linters (e.g. Prettier) will escape `$` , e.g.:

```md
## $accentColor
```

will be linted to

```md
## \$accentColor
```

So `\$` should be checked and unexcaped.


Also some people will use katex or mathjax, superscript and subscript to display math or chemistry expression in their headings. Though vuepress is not providing these plugins by default, it's better that vuepress can handle them

## § 1.1

## Infomation about H<sub>2</sub>O

```md
## $\S$ 1.1

## Infomation about H~2~O
```
