### PR TITLE
fix: correct homepage URLs in package.json

### DIFF
--- a/packages/@vuepress/markdown-loader/package.json
+++ b/packages/@vuepress/markdown-loader/package.json
@@ -8,7 +8,7 @@
     "vue",
     "vuepress"
   ],
-  "homepage": "https://github.com/vuejs/vuepress/packages/@vuepress/markdown-loader#readme",
+  "homepage": "https://github.com/vuejs/vuepress/blob/master/packages/@vuepress/markdown-loader#readme",
   "bugs": {
     "url": "https://github.com/vuejs/vuepress/issues"
   },

--- a/packages/@vuepress/markdown/package.json
+++ b/packages/@vuepress/markdown/package.json
@@ -9,7 +9,7 @@
     "vue",
     "vuepress"
   ],
-  "homepage": "https://github.com/vuejs/vuepress/packages/@vuepress/markdown#readme",
+  "homepage": "https://github.com/vuejs/vuepress/blob/master/packages/@vuepress/markdown#readme",
   "bugs": {
     "url": "https://github.com/vuejs/vuepress/issues"
   },

--- a/packages/@vuepress/plugin-active-header-links/package.json
+++ b/packages/@vuepress/plugin-active-header-links/package.json
@@ -8,7 +8,7 @@
     "vue",
     "vuepress"
   ],
-  "homepage": "https://github.com/vuejs/vuepress/packages/@vuepress/plugin-active-header-links#readme",
+  "homepage": "https://github.com/vuejs/vuepress/blob/master/packages/@vuepress/plugin-active-header-links#readme",
   "bugs": {
     "url": "https://github.com/vuejs/vuepress/issues"
   },

--- a/packages/@vuepress/plugin-back-to-top/package.json
+++ b/packages/@vuepress/plugin-back-to-top/package.json
@@ -8,7 +8,7 @@
     "vue",
     "vuepress"
   ],
-  "homepage": "https://github.com/vuejs/vuepress/packages/@vuepress/back-to-top#readme",
+  "homepage": "https://github.com/vuejs/vuepress/blob/master/packages/@vuepress/back-to-top#readme",
   "bugs": {
     "url": "https://github.com/vuejs/vuepress/issues"
   },

--- a/packages/@vuepress/plugin-google-analytics/package.json
+++ b/packages/@vuepress/plugin-google-analytics/package.json
@@ -8,7 +8,7 @@
     "vue",
     "vuepress"
   ],
-  "homepage": "https://github.com/vuejs/vuepress/packages/@vuepress/plugin-google-analytics#readme",
+  "homepage": "https://github.com/vuejs/vuepress/blob/master/packages/@vuepress/plugin-google-analytics#readme",
   "bugs": {
     "url": "https://github.com/vuejs/vuepress/issues"
   },

--- a/packages/@vuepress/plugin-last-updated/package.json
+++ b/packages/@vuepress/plugin-last-updated/package.json
@@ -8,7 +8,7 @@
     "vue",
     "vuepress"
   ],
-  "homepage": "https://github.com/vuejs/vuepress/packages/@vuepress/plugin-last-updated#readme",
+  "homepage": "https://github.com/vuejs/vuepress/blob/master/packages/@vuepress/plugin-last-updated#readme",
   "bugs": {
     "url": "https://github.com/vuejs/vuepress/issues"
   },

--- a/packages/@vuepress/plugin-medium-zoom/package.json
+++ b/packages/@vuepress/plugin-medium-zoom/package.json
@@ -8,7 +8,7 @@
     "vue",
     "vuepress"
   ],
-  "homepage": "https://github.com/vuejs/vuepress/packages/@vuepress/plugin-medium-zoom#readme",
+  "homepage": "https://github.com/vuejs/vuepress/blob/master/packages/@vuepress/plugin-medium-zoom#readme",
   "bugs": {
     "url": "https://github.com/vuejs/vuepress/issues"
   },

--- a/packages/@vuepress/plugin-nprogress/package.json
+++ b/packages/@vuepress/plugin-nprogress/package.json
@@ -8,7 +8,7 @@
     "vue",
     "vuepress"
   ],
-  "homepage": "https://github.com/vuejs/vuepress/packages/@vuepress/plugin-nprogress#readme",
+  "homepage": "https://github.com/vuejs/vuepress/blob/master/packages/@vuepress/plugin-nprogress#readme",
   "bugs": {
     "url": "https://github.com/vuejs/vuepress/issues"
   },

--- a/packages/@vuepress/plugin-pwa/package.json
+++ b/packages/@vuepress/plugin-pwa/package.json
@@ -8,7 +8,7 @@
     "vue",
     "vuepress"
   ],
-  "homepage": "https://github.com/vuejs/vuepress/packages/@vuepress/plugin-pwa#readme",
+  "homepage": "https://github.com/vuejs/vuepress/blob/master/packages/@vuepress/plugin-pwa#readme",
   "bugs": {
     "url": "https://github.com/vuejs/vuepress/issues"
   },

--- a/packages/@vuepress/plugin-register-components/package.json
+++ b/packages/@vuepress/plugin-register-components/package.json
@@ -8,7 +8,7 @@
     "vue",
     "vuepress"
   ],
-  "homepage": "https://github.com/vuejs/vuepress/packages/@vuepress/plugin-register-components#readme",
+  "homepage": "https://github.com/vuejs/vuepress/blob/master/packages/@vuepress/plugin-register-components#readme",
   "bugs": {
     "url": "https://github.com/vuejs/vuepress/issues"
   },

--- a/packages/@vuepress/plugin-search/package.json
+++ b/packages/@vuepress/plugin-search/package.json
@@ -8,7 +8,7 @@
     "vue",
     "vuepress"
   ],
-  "homepage": "https://github.com/vuejs/vuepress/packages/@vuepress/plugin-search#readme",
+  "homepage": "https://github.com/vuejs/vuepress/blob/master/packages/@vuepress/plugin-search#readme",
   "bugs": {
     "url": "https://github.com/vuejs/vuepress/issues"
   },

--- a/packages/@vuepress/shared-utils/package.json
+++ b/packages/@vuepress/shared-utils/package.json
@@ -8,7 +8,7 @@
     "vue",
     "vuepress"
   ],
-  "homepage": "https://github.com/vuejs/vuepress/packages/@vuepress/shared-utils#readme",
+  "homepage": "https://github.com/vuejs/vuepress/blob/master/packages/@vuepress/shared-utils#readme",
   "bugs": {
     "url": "https://github.com/vuejs/vuepress/issues"
   },

--- a/packages/@vuepress/test-utils/package.json
+++ b/packages/@vuepress/test-utils/package.json
@@ -8,7 +8,7 @@
     "vue",
     "vuepress"
   ],
-  "homepage": "https://github.com/vuejs/vuepress/packages/@vuepress/test-utils#readme",
+  "homepage": "https://github.com/vuejs/vuepress/blob/master/packages/@vuepress/test-utils#readme",
   "bugs": {
     "url": "https://github.com/vuejs/vuepress/issues"
   },

--- a/packages/@vuepress/theme-default/package.json
+++ b/packages/@vuepress/theme-default/package.json
@@ -8,7 +8,7 @@
     "vue",
     "vuepress"
   ],
-  "homepage": "https://github.com/vuejs/vuepress/packages/@vuepress/theme-default#readme",
+  "homepage": "https://github.com/vuejs/vuepress/blob/master/packages/@vuepress/theme-default#readme",
   "bugs": {
     "url": "https://github.com/vuejs/vuepress/issues"
   },

--- a/packages/@vuepress/theme-vue/package.json
+++ b/packages/@vuepress/theme-vue/package.json
@@ -8,7 +8,7 @@
     "vue",
     "vuepress"
   ],
-  "homepage": "https://github.com/vuejs/vuepress/packages/@vuepress/theme-vue#readme",
+  "homepage": "https://github.com/vuejs/vuepress/blob/master/packages/@vuepress/theme-vue#readme",
   "bugs": {
     "url": "https://github.com/vuejs/vuepress/issues"
   },

--- a/scripts/bootstrap.js
+++ b/scripts/bootstrap.js
@@ -40,7 +40,7 @@ files.forEach(pkg => {
       'bugs': {
         'url': 'https://github.com/vuejs/vuepress/issues'
       },
-      'homepage': `https://github.com/vuejs/vuepress/packages/@vuepress/${pkg}#readme`
+      'homepage': `https://github.com/vuejs/vuepress/blob/master/packages/@vuepress/${pkg}#readme`
     }
     fs.writeFileSync(pkgPath, JSON.stringify(json, null, 2))
   }


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

`homepage` link is error in packages/@vuepress/${pkg}/package.json

Example: Click the [@vuepress/theme-default](https://www.npmjs.com/package/@vuepress/theme-default) homepage link to visit page 404

**What kind of change does this PR introduce?** (check at least one)

- [x ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of default theme, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x ] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

You have tested in the following browsers: (Providing a detailed version will be better.)

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
- [ ] IE

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature
- [ ] Related documents have been updated
- [ ] Related tests have been updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
