### PR TITLE
docs #2401: using markdown in component slots

### DIFF
--- a/packages/docs/docs/guide/using-vue.md
+++ b/packages/docs/docs/guide/using-vue.md
@@ -155,6 +155,42 @@ Inside any Markdown file you can then directly use the components (names are inf
 Make sure a custom component’s name either contains a hyphen or is in PascalCase. Otherwise it will be treated as an inline element and wrapped inside a `<p>` tag, which will lead to hydration mismatch because `<p>` does not allow block elements to be placed inside it.
 :::
 
+### Using Markdown Inside Component Slots
+
+You can write markdown inside html elements by leaving an empty line before and after the markdown content. This feature allows you to use markdown inside components with [slots](https://vuejs.org/v2/guide/components-slots.html).
+
+``` md
+<ComponentWithSlot>
+
+## This Markdown
+
+- will be converted
+- to correct html
+- then rendered in a `<slot>` inside ComponentWithSlot
+
+</ComponentWithSlot>
+```
+
+You can use markdown in multiple [named slots](https://vuejs.org/v2/guide/components-slots.html#Named-Slots), with empty lines before and after each part of your markdown content, for eample:
+
+``` md
+<ComponentWithSlots>
+  <template v-slot:header>
+
+  ### This Content
+  Will go in a slot named "header"
+
+  </template>
+
+> This markdown content will go in the *default* slot
+
+</ComponentWithSlots>
+```
+
+::: warning
+You must specify named slots using `v-slot:`, not the `#` shorthand.
+:::
+
 ### Using Components In Headers
 
 You can use Vue components in the headers, but note the difference between the following two ways:


### PR DESCRIPTION
**Summary**

Documentation on how to use markdown in component slots with:
- code examples for single slot and named slots with empty lines before and after markdown,
- warning about not using # shorthand for named slots.

This is an awesome feature that deserves to be documented so that people know it's available and understand how to use it correctly.

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [x] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of default theme, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

You have tested in the following browsers: (Providing a detailed version will be better.)

- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
- [ ] IE

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature
- [ ] Related documents have been updated
- [ ] Related tests have been updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
