### PR TITLE
fix($core): check if meta is from head before removing it

### DIFF
--- a/packages/@vuepress/core/lib/client/root-mixins/updateMeta.js
+++ b/packages/@vuepress/core/lib/client/root-mixins/updateMeta.js
@@ -61,10 +61,9 @@ export default {
  */
 function updateMetaTags (newMetaTags, currentMetaTags) {
   if (currentMetaTags) {
-    [...currentMetaTags].filter(c => c.parentNode === document.head)
-      .forEach(c => {
-        document.head.removeChild(c)
-      })
+    [...currentMetaTags]
+          .filter(c => c.parentNode === document.head)
+          .forEach(c => document.head.removeChild(c))
   }
   if (newMetaTags) {
     return newMetaTags.map(m => {

--- a/packages/@vuepress/core/lib/client/root-mixins/updateMeta.js
+++ b/packages/@vuepress/core/lib/client/root-mixins/updateMeta.js
@@ -61,9 +61,10 @@ export default {
  */
 function updateMetaTags (newMetaTags, currentMetaTags) {
   if (currentMetaTags) {
-    [...currentMetaTags].forEach(c => {
-      document.head.removeChild(c)
-    })
+    [...currentMetaTags].filter(c => c.parentNode === document.head)
+      .forEach(c => {
+        document.head.removeChild(c)
+      })
   }
   if (newMetaTags) {
     return newMetaTags.map(m => {


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

@chriscdn opened this https://github.com/vuepressjs/vuepress-theme-blog/issues/78, he is having an issue with `<meta>` trying to be removed from `document.head` whereas they where not `document.head`'s children.

This can happens when you use `<meta>` in `<body>` for microdatas. This is automatically done by the blog plugin since https://github.com/vuepressjs/vuepress-theme-blog/pull/64.

![Capture d’écran de 2020-05-23 22-03-37](https://user-images.githubusercontent.com/2103975/82740105-d92b0180-9d45-11ea-8cc4-81e73be6efd2.png)

After the fix, _global_ `<meta>` and `<meta>` in `<body>` are still at the good place: 
![Capture d’écran de 2020-05-23 22-28-10](https://user-images.githubusercontent.com/2103975/82740109-e6e08700-9d45-11ea-9eff-75ee1a3b6a34.png)

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of default theme, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

You have tested in the following browsers: (Providing a detailed version will be better.)

- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
- [ ] IE

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature
- [ ] Related documents have been updated
- [ ] Related tests have been updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**

I would like to add a test to prevent a regression, but it looks like there is not tests for `core/lib/client/*`.. or maybe I am missing something?
Thanks!