### PR TITLE
feat($theme-default): add initial open group index option

### DIFF
--- a/packages/@vuepress/theme-default/components/SidebarGroup.vue
+++ b/packages/@vuepress/theme-default/components/SidebarGroup.vue
@@ -47,6 +47,7 @@
         class="sidebar-group-items"
         :items="item.children"
         :sidebar-depth="item.sidebarDepth"
+        :initial-open-group-index="item.initialOpenGroupIndex"
         :depth="depth + 1"
       />
     </DropdownTransition>

--- a/packages/@vuepress/theme-default/components/SidebarLinks.vue
+++ b/packages/@vuepress/theme-default/components/SidebarLinks.vue
@@ -37,12 +37,13 @@ export default {
   props: [
     'items',
     'depth',  // depth of current sidebar links
-    'sidebarDepth' // depth of headers to be extracted
+    'sidebarDepth', // depth of headers to be extracted
+    'initialOpenGroupIndex'
   ],
 
   data () {
     return {
-      openGroupIndex: 0
+      openGroupIndex: this.initialOpenGroupIndex || 0
     }
   },
 

--- a/packages/@vuepress/theme-default/util/index.js
+++ b/packages/@vuepress/theme-default/util/index.js
@@ -236,6 +236,7 @@ function resolveItem (item, pages, base, groupDepth = 1) {
       path: item.path,
       title: item.title,
       sidebarDepth: item.sidebarDepth,
+      initialOpenGroupIndex: item.initialOpenGroupIndex,
       children: children.map(child => resolveItem(child, pages, base, groupDepth + 1)),
       collapsable: item.collapsable !== false
     }

--- a/packages/docs/docs/theme/default-theme-config.md
+++ b/packages/docs/docs/theme/default-theme-config.md
@@ -234,6 +234,8 @@ A sidebar group config also supports [sidebarDepth](#nested-header-links) field 
 
 ::: tip
    Nested sidebar group is also supported.
+   By default the first subgroup is opened initially.
+   You can change this using the `initialOpenGroupIndex`: Specify an index to open another subgroup or use `-1` for no open group.
 :::
 
 ### Multiple Sidebars

--- a/packages/docs/docs/theme/default-theme-config.md
+++ b/packages/docs/docs/theme/default-theme-config.md
@@ -220,7 +220,8 @@ module.exports = {
       },
       {
         title: 'Group 2',
-        children: [ /* ... */ ]
+        children: [ /* ... */ ],
+        initialOpenGroupIndex: -1 // optional, defaults to 0, defines the index of initially opened subgroup
       }
     ]
   }

--- a/packages/docs/docs/zh/theme/default-theme-config.md
+++ b/packages/docs/docs/zh/theme/default-theme-config.md
@@ -218,7 +218,8 @@ module.exports = {
       },
       {
         title: 'Group 2',
-        children: [ /* ... */ ]
+        children: [ /* ... */ ],
+        initialOpenGroupIndex: -1 // 可选的, 默认值是 0
       }
     ]
   }


### PR DESCRIPTION
**Summary**

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**The PR fulfills these requirements:**

You have tested in the following browsers: (Providing a detailed version will be better.)

- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge
- [ ] IE

If adding a **new feature**, the PR's description includes:

- [x] A convincing reason for adding this feature
- [x] Related documents have been updated
- [ ] Related tests have been updated

Adds an optional property for sidebar groups, so that one can initially display a group other than the first as open. Also allows to initially display all groups as closed, by setting `initialOpenGroupIndex` to `-1`.
