### PR TITLE
feat($markdown): Support for Elixir file extensions

### DIFF
--- a/packages/@vuepress/markdown/lib/highlight.js
+++ b/packages/@vuepress/markdown/lib/highlight.js
@@ -24,7 +24,9 @@ function getLangCodeFromExtension (extension) {
     yml: 'yaml',
     styl: 'stylus',
     kt: 'kotlin',
-    rs: 'rust'
+    rs: 'rust',
+    ex: 'elixir',
+    exs: 'elixir'
   }
 
   return extensionMap[extension] || extension


### PR DESCRIPTION
Currently, code from Elixir files is not being highlighted. This can be resolved by mapping the Elixir file endings to the name.