### PR TITLE
Manifest and PWA setup to deploy to GH-pages

### DIFF
--- a/packages/docs/docs/guide/deploy.md
+++ b/packages/docs/docs/guide/deploy.md
@@ -56,6 +56,27 @@ cd -
 You can also run the above script in your CI setup to enable automatic deployment on each push.
 :::
 
+::: warning
+If you will deploy your site to `https://<USERNAME or GROUP>.github.io/<REPO>/`, (that is your repository is at `https://github.com/<USERNAME>/<REPO>`), you should set `scope` and `start_url` to `"/<REPO>/"` in your `manifest.json`, to get PWA working properly.
+
+And your icons should use relative paths
+
+```json
+//manifest.json
+
+  ...
+  "scope": "/<REPO>/",
+  "start_url": "/<REPO>/",
+  "icons": [
+    {
+      "src": "icons/android-chrome-192x192.png",
+      ...
+    }
+  ]
+  ...
+```
+:::
+
 ### GitHub Pages and Travis CI
 
 1. Set correct `base` in `docs/.vuepress/config.js`.


### PR DESCRIPTION
When deploying to Github pages its necessary to set scope and start_url to "repo" path, otherwise, the site won't be able to prompt the installation dialog, and lighthouse tool will always warn: "start_url does not respond with a 200 when offline", that's because the browser will fetch https://username.github.io/ instead of https://username.github.io/repo/.

<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [x] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of default theme, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

You have tested in the following browsers: (Providing a detailed version will be better.)

- [x] Chrome
- [x] Firefox
- [ ] Safari
- [x] Edge
- [ ] IE

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature
- [ ] Related documents have been updated
- [ ] Related tests have been updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
