### PR TITLE
fix($markdown): line highlighting not working correctly when importing code snippets

### DIFF
--- a/packages/@vuepress/markdown/__tests__/__snapshots__/snippet.spec.js.snap
+++ b/packages/@vuepress/markdown/__tests__/__snapshots__/snippet.spec.js.snap
@@ -1,6 +1,13 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`snippet import snippets when the file has a space in the file path 1`] = `
+exports[`snippet import snippet 1`] = `
+<pre><code class="language-js">export default function () {
+  // ..
+}
+</code></pre>
+`;
+
+exports[`snippet import snippet with highlight multiple lines 1`] = `
 <div class="highlight-lines">
   <div class="highlighted">&nbsp;</div>
   <div class="highlighted">&nbsp;</div>
@@ -10,45 +17,7 @@ exports[`snippet import snippets when the file has a space in the file path 1`] 
 }
 `;
 
-exports[`snippet import snippet 1`] = `
-<pre><code class="language-js">export default function () {
-  // ..
-}
-</code></pre>
-`;
-
-exports[`snippet import snippet with region and highlight 1`] = `
-<pre><code class="language-js{1,3}">function foo () {
-  return ({
-    dest: '../../vuepress',
-    locales: {
-      '/': {
-        lang: 'en-US',
-        title: 'VuePress',
-        description: 'Vue-powered Static Site Generator'
-      },
-      '/zh/': {
-        lang: 'zh-CN',
-        title: 'VuePress',
-        description: 'Vue 驱动的静态网站生成器'
-      }
-    },
-    head: [
-      ['link', { rel: 'icon', href: \`/logo.png\` }],
-      ['link', { rel: 'manifest', href: '/manifest.json' }],
-      ['meta', { name: 'theme-color', content: '#3eaf7c' }],
-      ['meta', { name: 'apple-mobile-web-app-capable', content: 'yes' }],
-      ['meta', { name: 'apple-mobile-web-app-status-bar-style', content: 'black' }],
-      ['link', { rel: 'apple-touch-icon', href: \`/icons/apple-touch-icon-152x152.png\` }],
-      ['link', { rel: 'mask-icon', href: '/icons/safari-pinned-tab.svg', color: '#3eaf7c' }],
-      ['meta', { name: 'msapplication-TileImage', content: '/icons/msapplication-icon-144x144.png' }],
-      ['meta', { name: 'msapplication-TileColor', content: '#000000' }]
-    ]
-  })
-}</code></pre>
-`;
-
-exports[`snippet import snippet with highlight multiple lines 1`] = `
+exports[`snippet import snippet with highlight single and multiple lines 1`] = `
 <div class="highlight-lines">
   <div class="highlighted">&nbsp;</div>
   <div class="highlighted">&nbsp;</div>
@@ -105,7 +74,38 @@ exports[`snippet import snippet with region 1`] = `
 }</code></pre>
 `;
 
-exports[`snippet import snippet with region and single line highlight > 10 1`]  = `
+exports[`snippet import snippet with region and highlight 1`] = `
+<pre><code class="language-js{1,3}">function foo () {
+  return ({
+    dest: '../../vuepress',
+    locales: {
+      '/': {
+        lang: 'en-US',
+        title: 'VuePress',
+        description: 'Vue-powered Static Site Generator'
+      },
+      '/zh/': {
+        lang: 'zh-CN',
+        title: 'VuePress',
+        description: 'Vue 驱动的静态网站生成器'
+      }
+    },
+    head: [
+      ['link', { rel: 'icon', href: \`/logo.png\` }],
+      ['link', { rel: 'manifest', href: '/manifest.json' }],
+      ['meta', { name: 'theme-color', content: '#3eaf7c' }],
+      ['meta', { name: 'apple-mobile-web-app-capable', content: 'yes' }],
+      ['meta', { name: 'apple-mobile-web-app-status-bar-style', content: 'black' }],
+      ['link', { rel: 'apple-touch-icon', href: \`/icons/apple-touch-icon-152x152.png\` }],
+      ['link', { rel: 'mask-icon', href: '/icons/safari-pinned-tab.svg', color: '#3eaf7c' }],
+      ['meta', { name: 'msapplication-TileImage', content: '/icons/msapplication-icon-144x144.png' }],
+      ['meta', { name: 'msapplication-TileColor', content: '#000000' }]
+    ]
+  })
+}</code></pre>
+`;
+
+exports[`snippet import snippet with region and single line highlight > 10 1`] = `
 <pre><code class="language-js{11}">function foo () {
   return ({
     dest: '../../vuepress',
@@ -134,4 +134,14 @@ exports[`snippet import snippet with region and single line highlight > 10 1`]  
     ]
   })
 }</code></pre>
+`;
+
+exports[`snippet import snippets when the file has a space in the file path 1`] = `
+<div class="highlight-lines">
+  <div class="highlighted">&nbsp;</div>
+  <div class="highlighted">&nbsp;</div>
+  <div class="highlighted">&nbsp;</div><br>
+</div>export default function () {
+// ..
+}
 `;

--- a/packages/@vuepress/markdown/__tests__/fragments/code-snippet-highlightLines-single-and-multiple.md
+++ b/packages/@vuepress/markdown/__tests__/fragments/code-snippet-highlightLines-single-and-multiple.md
@@ -1,0 +1,1 @@
+<<< @/packages/@vuepress/markdown/__tests__/fragments/snippet.js{1-2,3}

--- a/packages/@vuepress/markdown/__tests__/snippet.spec.js
+++ b/packages/@vuepress/markdown/__tests__/snippet.spec.js
@@ -25,6 +25,12 @@ describe('snippet', () => {
     expect(output).toMatchSnapshot()
   })
 
+  test('import snippet with highlight single and multiple lines', () => {
+    const input = getFragment(__dirname, 'code-snippet-highlightLines-single-and-multiple.md')
+    const output = mdH.render(input)
+    expect(output).toMatchSnapshot()
+  })
+
   test('import snippets when the file has a space in the file path', () => {
     const input = getFragment(__dirname, 'code-snippet-with-space-in-path.md')
     const output = mdH.render(input)

--- a/packages/@vuepress/markdown/lib/snippet.js
+++ b/packages/@vuepress/markdown/lib/snippet.js
@@ -137,7 +137,7 @@ module.exports = function snippet (md, options = {}) {
      *
      * captures: ['/path/to/file.extension', 'extension', '#region', '{meta}']
      */
-    const rawPathRegexp = /^(.+(?:\.([a-z]+)))(?:(#[\w-]+))?(?: ?({\d+(?:[,-]\d+)?}))?$/
+    const rawPathRegexp = /^(.+(?:\.([a-z]+)))(?:(#[\w-]+))?(?: ?({\d+(?:[,-]\d+)*}))?$/
 
     const rawPath = state.src.slice(start, end).trim().replace(/^@/, root).trim()
     const [filename = '', extension = '', region = '', meta = ''] = (rawPathRegexp.exec(rawPath) || []).slice(1)


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

When importing code snippets with the `<<<` syntax, you could only either specify a single range (`{34-37}`) or a maximum of two lines to be highlighted (`{3,6}`).

This PR fixes the regex that was matching the syntax so it allows for unlimited line highlights like the ` ``` ` syntax.

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of default theme, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

You have tested in the following browsers: (Providing a detailed version will be better.)

- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
- [ ] IE

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature
- [ ] Related documents have been updated
- [ ] Related tests have been updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**

Before this PR, a snippet like
```
<<< @/path/to/file.js{5-7,10-16,25}
```
would output `Invalid code snippet option`.

**Old regex:**
![image](https://user-images.githubusercontent.com/7467891/84371906-435ef580-abd2-11ea-933b-8be014ee8004.png)

**New regex:**
![image](https://user-images.githubusercontent.com/7467891/84371945-5245a800-abd2-11ea-96e6-c07d9c18ee5c.png)
