### PR TITLE
docs: add missing `dateOptions` for `last-updated` plugin

### DIFF
--- a/packages/docs/docs/zh/plugin/official/plugin-last-updated.md
+++ b/packages/docs/docs/zh/plugin/official/plugin-last-updated.md
@@ -23,7 +23,7 @@ module.exports = {
 
 ### transformer
 
-- Type: `(timestamp: number, lang: string) => string`
+- 类型: `(timestamp: number, lang: string) => string`
 - 默认值: `undefined`
 
 默认情况下，本插件为每个页面生成一个 13 位的时间戳，你可以传入一个 transformer 将其转换为你想要的任何格式。
@@ -51,7 +51,29 @@ module.exports = {
 ```
 
 ::: tip
-如果你在 [i18n](../../guide/i18n.md) 模式下运行，你还可以使用第二个参数 `lang` 为不同语言生成时间字符串。
+如果你在[多语言](../../guide/i18n.md)模式下运行，你还可以使用第二个参数 `lang` 为不同语言生成时间字符串。
 
 请注意，在 VuePress 中，我们遵循以下规范：[W3C > Language tags in HTML and XML](https://en.wikipedia.org/wiki/Language_localisation)，因此 `zh-CN` 使用连字符（`-`）而不是下划线（`_`）。 请确保你使用的库遵循此规范，否则请自行转换。
 :::
+
+### dateOptions
+
+- 类型: `object`
+- 默认值: `undefined`
+
+你也可以传入一个对象作为选项，以自定义时间戳的输出格式。详细信息请参阅 [`Date.prototype.toLocaleString()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleString) 的选项参数。
+
+```javascript
+module.exports = {
+  plugins: [
+    [
+      '@vuepress/last-updated',
+      {
+        dateOptions:{
+          hour12: false
+        }
+      }
+    ]
+  ]
+}
+```


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

Add missing `dateOptions` for `last-updated` plugin in Chinese documentation.

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [x] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of default theme, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

You have tested in the following browsers: (Providing a detailed version will be better.)

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
- [ ] IE

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature
- [ ] Related documents have been updated
- [ ] Related tests have been updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
