### PR TITLE
fix($theme-default): fix editLink for repos hosted on gitlab.com

### DIFF
--- a/packages/@vuepress/theme-default/components/PageEdit.vue
+++ b/packages/@vuepress/theme-default/components/PageEdit.vue
@@ -97,7 +97,7 @@ export default {
         : `https://github.com/${docsRepo}`
       return (
         base.replace(endingSlashRE, '')
-        + `/edit`
+        + (/gitlab.com/.test(repo) ? '/-/edit/' : '/edit')
         + `/${docsBranch}/`
         + (docsDir ? docsDir.replace(endingSlashRE, '') + '/' : '')
         + path

--- a/packages/@vuepress/theme-default/components/PageEdit.vue
+++ b/packages/@vuepress/theme-default/components/PageEdit.vue
@@ -80,8 +80,8 @@ export default {
   methods: {
     createEditLink (repo, docsRepo, docsDir, docsBranch, path) {
       const bitbucket = /bitbucket.org/
-      if (bitbucket.test(repo)) {
-        const base = outboundRE.test(docsRepo) ? docsRepo : repo
+      if (bitbucket.test(docsRepo)) {
+        const base = docsRepo
         return (
           base.replace(endingSlashRE, '')
           + `/src`

--- a/packages/@vuepress/theme-default/components/PageEdit.vue
+++ b/packages/@vuepress/theme-default/components/PageEdit.vue
@@ -92,12 +92,24 @@ export default {
         )
       }
 
+      const gitlab = /gitlab.com/
+      if (gitlab.test(docsRepo)) {
+        const base = docsRepo
+        return (
+          base.replace(endingSlashRE, '')
+          + `/-/edit`
+          + `/${docsBranch}/`
+          + (docsDir ? docsDir.replace(endingSlashRE, '') + '/' : '')
+          + path
+        )
+      }
+
       const base = outboundRE.test(docsRepo)
         ? docsRepo
         : `https://github.com/${docsRepo}`
       return (
         base.replace(endingSlashRE, '')
-        + (/gitlab.com/.test(repo) ? '/-/edit/' : '/edit')
+        + '/edit'
         + `/${docsBranch}/`
         + (docsDir ? docsDir.replace(endingSlashRE, '') + '/' : '')
         + path


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**
Urls that open files in the web editor follow a slightly different structure on GitLab and GitHub. This is why currently the `editLink`s in VuePress are broken for every GitLab repo.

- GitLab:
    ```
    https://gitlab.com/inkscape/inkscape/-/edit/master/.gitlab-ci.yml
    ```
- GitHub:
    ```
    https://github.com/vuejs/vuepress/edit/master/README.md
    ```

The difference is that the repository's name is followed by `/-` in the GitLab links. This PR attempts to fix this issue.

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of default theme, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

You have tested in the following browsers: (Providing a detailed version will be better.)

- [x] Chrome
- [x]  Firefox
- [x] Safari
- [ ] Edge
- [ ] IE

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature
- [ ] Related documents have been updated
- [ ] Related tests have been updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**

_Tests_
Unfortunately if you attempt to edit a file on GitLab without having proper permissions, you are redirected to the blob (but there are no warning messages displayed). To properly test this PR you need a GitLab account and a GitLab repo where you have rights to editing files.

Since the only file I modified (`packages/@vuepress/theme-default/components/PageEdit.vue`) has no tests and my changes are quite small and straight-forward, I did not add new test cases to this PR.

Please let me know if you need more information, or if this PR doesn't meet the requirements! ☺️
