### PR TITLE
feat() #578: add support for specifying image width and height

### DIFF
--- a/packages/@vuepress/markdown/index.js
+++ b/packages/@vuepress/markdown/index.js
@@ -17,6 +17,8 @@ const snippetPlugin = require('./lib/snippet')
 const emojiPlugin = require('markdown-it-emoji')
 const anchorPlugin = require('markdown-it-anchor')
 const tocPlugin = require('markdown-it-table-of-contents')
+const imgSizePlugin = require('markdown-it-imsize')
+
 const {
   slugify: _slugify,
   parseHeaders,
@@ -33,6 +35,7 @@ module.exports = (markdown = {}) => {
     externalLinks,
     anchor,
     toc,
+    imgSize,
     plugins,
     lineNumbers,
     beforeInstantiate,
@@ -100,6 +103,14 @@ module.exports = (markdown = {}) => {
         format: parseHeaders
       }, toc)])
       .end()
+
+    .plugin(PLUGINS.IMG_SIZE)
+      .use(imgSizePlugin, [Object.assign({
+        html: true,
+        linkify: true,
+        typography: true
+      }, imgSize)])
+    .end()
 
   if (lineNumbers) {
     config

--- a/packages/@vuepress/markdown/lib/constant.js
+++ b/packages/@vuepress/markdown/lib/constant.js
@@ -1,17 +1,18 @@
 exports.PLUGINS = {
+  ANCHOR: 'anchor',
   COMPONENT: 'component',
+  CONVERT_ROUTER_LINK: 'convert-router-link',
+  EMOJI: 'emoji',
   HIGHLIGHT_LINES: 'highlight-lines',
+  HOIST_SCRIPT_STYLE: 'hoist-script-style',
+  IMG_SIZE: 'img-size',
+  LINE_NUMBERS: 'line-numbers',
   PRE_WRAPPER: 'pre-wrapper',
   SNIPPET: 'snippet',
-  CONVERT_ROUTER_LINK: 'convert-router-link',
-  HOIST_SCRIPT_STYLE: 'hoist-script-style',
-  ANCHOR: 'anchor',
-  EMOJI: 'emoji',
-  TOC: 'toc',
-  LINE_NUMBERS: 'line-numbers'
+  TOC: 'toc'
 }
 
 exports.REQUIRED_PLUGINS = [
-  exports.PLUGINS.COMPONENT,
-  exports.PLUGINS.ANCHOR
+  exports.PLUGINS.ANCHOR,
+  exports.PLUGINS.COMPONENT
 ]

--- a/packages/@vuepress/markdown/package.json
+++ b/packages/@vuepress/markdown/package.json
@@ -27,6 +27,7 @@
     "markdown-it-anchor": "^5.0.2",
     "markdown-it-chain": "^1.3.0",
     "markdown-it-emoji": "^1.4.0",
+    "markdown-it-imsize": "^2.0.1",
     "markdown-it-table-of-contents": "^0.4.0",
     "prismjs": "^1.13.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -8756,6 +8756,11 @@ markdown-it-emoji@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/markdown-it-emoji/-/markdown-it-emoji-1.4.0.tgz#9bee0e9a990a963ba96df6980c4fddb05dfb4dcc"
 
+markdown-it-imsize@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/markdown-it-imsize/-/markdown-it-imsize-2.0.1.tgz#cca0427905d05338a247cb9ca9d968c5cddd5170"
+  integrity sha1-zKBCeQXQUziiR8ucqdloxc3dUXA=
+
 markdown-it-table-of-contents@^0.4.0:
   version "0.4.4"
   resolved "https://registry.yarnpkg.com/markdown-it-table-of-contents/-/markdown-it-table-of-contents-0.4.4.tgz#3dc7ce8b8fc17e5981c77cc398d1782319f37fbc"
@@ -9127,7 +9132,7 @@ mkdirp-promise@^5.0.1:
   dependencies:
     mkdirp "*"
 
-mkdirp@*, mkdirp@0.5.x, mkdirp@0.x, mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0, mkdirp@~0.5.1, mkdirp@~0.5.x:
+mkdirp@*, mkdirp@0.5.x, mkdirp@0.x, mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0, mkdirp@~0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
   dependencies:
@@ -9137,6 +9142,11 @@ mkdirp@0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.3.0.tgz#1bbf5ab1ba827af23575143490426455f481fe1e"
   integrity sha1-G79asbqCevI1dRQ0kEJkVfSB/h4=
+
+mkdirp@~1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
+  integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
 
 modify-values@^1.0.0:
   version "1.0.1"
@@ -12565,18 +12575,18 @@ stylus-loader@^3.0.2:
     lodash.clonedeep "^4.5.0"
     when "~3.6.x"
 
-stylus@^0.54.5:
-  version "0.54.7"
-  resolved "https://registry.yarnpkg.com/stylus/-/stylus-0.54.7.tgz#c6ce4793965ee538bcebe50f31537bfc04d88cd2"
-  integrity sha512-Yw3WMTzVwevT6ZTrLCYNHAFmanMxdylelL3hkWNgPMeTCpMwpV3nXjpOHuBXtFv7aiO2xRuQS6OoAdgkNcSNug==
+stylus@^0.54.8:
+  version "0.54.8"
+  resolved "https://registry.yarnpkg.com/stylus/-/stylus-0.54.8.tgz#3da3e65966bc567a7b044bfe0eece653e099d147"
+  integrity sha512-vr54Or4BZ7pJafo2mpf0ZcwA74rpuYCZbxrHBsH8kbcXOwSfvBFwsRfpGO5OD5fhG5HDCFW737PKaawI7OqEAg==
   dependencies:
     css-parse "~2.0.0"
     debug "~3.1.0"
-    glob "^7.1.3"
-    mkdirp "~0.5.x"
+    glob "^7.1.6"
+    mkdirp "~1.0.4"
     safer-buffer "^2.1.2"
     sax "~1.2.4"
-    semver "^6.0.0"
+    semver "^6.3.0"
     source-map "^0.7.3"
 
 supports-color@^2.0.0:


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**
This changes makes it easier for people to define absolute width/height dimensions for their images. The issue #578 asks for Vuepress to detect image sizes on build, but this would be a breaking change for many sites that expect their images to be responsive to the parent container. This new feature helps solve the issue present in #578 without requiring a breaking change.

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of default theme, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

You have tested in the following browsers: (Providing a detailed version will be better.)

- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
- [ ] IE

If adding a **new feature**, the PR's description includes:

- [x] A convincing reason for adding this feature
- [ ] Related documents have been updated
- [ ] Related tests have been updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
