### PR TITLE
refactor($core): catch initial push to avoid warning

### DIFF
--- a/packages/@vuepress/core/lib/client/serverEntry.js
+++ b/packages/@vuepress/core/lib/client/serverEntry.js
@@ -9,7 +9,8 @@ export default context => new Promise((resolve, reject) => {
       return reject({ url: fullPath })
     }
 
-    router.push(url)
-    router.onReady(() => resolve(app))
+    // error handled in onReady
+    router.push(url).catch(() => {})
+    router.onReady(() => resolve(app), reject)
   })
 })

--- a/packages/@vuepress/core/package.json
+++ b/packages/@vuepress/core/package.json
@@ -51,7 +51,7 @@
     "url-loader": "^1.0.1",
     "vue": "^2.6.10",
     "vue-loader": "^15.7.1",
-    "vue-router": "^3.1.3",
+    "vue-router": "^3.4.5",
     "vue-server-renderer": "^2.6.10",
     "vue-template-compiler": "^2.6.10",
     "vuepress-html-webpack-plugin": "^3.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13715,10 +13715,10 @@ vue-loader@^15.7.1:
     vue-hot-reload-api "^2.3.0"
     vue-style-loader "^4.1.0"
 
-vue-router@^3.1.3:
-  version "3.1.3"
-  resolved "https://registry.yarnpkg.com/vue-router/-/vue-router-3.1.3.tgz#e6b14fabc0c0ee9fda0e2cbbda74b350e28e412b"
-  integrity sha512-8iSa4mGNXBjyuSZFCCO4fiKfvzqk+mhL0lnKuGcQtO1eoj8nq3CmbEG8FwK5QqoqwDgsjsf1GDuisDX4cdb/aQ==
+vue-router@^3.4.5:
+  version "3.4.5"
+  resolved "https://registry.yarnpkg.com/vue-router/-/vue-router-3.4.5.tgz#d396ec037b35931bdd1e9b7edd86f9788dc15175"
+  integrity sha512-ioRY5QyDpXM9TDjOX6hX79gtaMXSVDDzSlbIlyAmbHNteIL81WIVB2e+jbzV23vzxtoV0krdS2XHm+GxFg+Nxg==
 
 vue-server-renderer@^2.6.10:
   version "2.6.10"


### PR DESCRIPTION
<!-- Please don't delete this template -->

Close #2606 
v3.4.5 fixed a bug with redirections on SSR, I added the `catch` to the initial push since `onReady` should still catch the error

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [x] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of default theme, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

You have tested in the following browsers: (Providing a detailed version will be better.)

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
- [ ] IE

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature
- [ ] Related documents have been updated
- [ ] Related tests have been updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
