### PR TITLE
fix ($plugin-pwa): popup zindex conflict (fix #2642)

### DIFF
--- a/packages/@vuepress/plugin-pwa/lib/SWUpdatePopup.vue
+++ b/packages/@vuepress/plugin-pwa/lib/SWUpdatePopup.vue
@@ -93,7 +93,7 @@ export default {
   background: #fff;
   box-shadow: 0 4px 16px rgba(0, 0, 0, 0.5);
   text-align: center;
-  z-index: 2;
+  z-index: 3;
 }
 
 .sw-update-popup > button {


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**
Changed z-index from 2 to 3 to avoid conflict with div[class*="language-"]::before elements

**What kind of change does this PR introduce?** (check at least one)

- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of default theme, please provide the **before/after** screenshot:

**before**
<img width="920" alt="Снимок экрана 2020-10-04 в 09 16 36" src="https://user-images.githubusercontent.com/29104068/95010873-76bc0900-0635-11eb-89c4-0ad9d112b1f2.png">

**after**
<img width="921" alt="Снимок экрана 2020-10-04 в 11 32 26" src="https://user-images.githubusercontent.com/29104068/95010884-86d3e880-0635-11eb-8eff-2e740b98f08d.png">


**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [X] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

You have tested in the following browsers: (Providing a detailed version will be better.)

- [X] Chrome
- [ ] Firefox
- [X] Safari
- [ ] Edge
- [ ] IE

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature
- [ ] Related documents have been updated
- [ ] Related tests have been updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
