### PR TITLE
feat($core): add canonical link to frontmatter

### DIFF
--- a/packages/@vuepress/core/lib/client/index.ssr.html
+++ b/packages/@vuepress/core/lib/client/index.ssr.html
@@ -7,7 +7,7 @@
     <meta name="generator" content="VuePress {{ version }}">
     {{{ userHeadTags }}}
     {{{ pageMeta }}}
-    {{{ canonical() }}}
+    {{{ canonical }}}
     {{{ renderResourceHints() }}}
     {{{ renderStyles() }}}
   </head>

--- a/packages/@vuepress/core/lib/client/index.ssr.html
+++ b/packages/@vuepress/core/lib/client/index.ssr.html
@@ -7,6 +7,7 @@
     <meta name="generator" content="VuePress {{ version }}">
     {{{ userHeadTags }}}
     {{{ pageMeta }}}
+    {{{ canonical() }}}
     {{{ renderResourceHints() }}}
     {{{ renderStyles() }}}
   </head>

--- a/packages/@vuepress/core/lib/client/index.ssr.html
+++ b/packages/@vuepress/core/lib/client/index.ssr.html
@@ -7,7 +7,7 @@
     <meta name="generator" content="VuePress {{ version }}">
     {{{ userHeadTags }}}
     {{{ pageMeta }}}
-    {{{ canonical }}}
+    {{{ canonicalLink }}}
     {{{ renderResourceHints() }}}
     {{{ renderStyles() }}}
   </head>

--- a/packages/@vuepress/core/lib/client/root-mixins/updateMeta.js
+++ b/packages/@vuepress/core/lib/client/root-mixins/updateMeta.js
@@ -13,6 +13,7 @@ export default {
       this.$ssrContext.title = this.$title
       this.$ssrContext.lang = this.$lang
       this.$ssrContext.pageMeta = renderPageMeta(mergedMetaItems)
+      this.$ssrContext.canonical = renderCanonical(this.$canonical)
     }
   },
   // Other life cycles will only be called at client
@@ -22,6 +23,7 @@ export default {
 
     // update title / meta tags
     this.updateMeta()
+    this.updateCanonical()
   },
 
   methods: {
@@ -39,6 +41,20 @@ export default {
       // description needs special attention as it has too many entries
       return unionBy([{ name: 'description', content: this.$description }],
         pageMeta, this.siteMeta, metaIdentifier)
+    },
+
+    updateCanonical () {
+      const canonicalEl = document.querySelector("link[rel='canonical']")
+
+      if (canonicalEl) {
+        canonicalEl.remove()
+      }
+
+      if (!this.$canonical) {
+        return
+      }
+
+      document.head.insertAdjacentHTML('beforeend', renderCanonical(this.$canonical))
     }
   },
 
@@ -51,6 +67,13 @@ export default {
   beforeDestroy () {
     updateMetaTags(null, this.currentMetaTags)
   }
+}
+
+function renderCanonical (link = '') {
+  if (!link) {
+    return ''
+  }
+  return `<link href="${link}" rel="canonical" />`
 }
 
 /**

--- a/packages/@vuepress/core/lib/client/root-mixins/updateMeta.js
+++ b/packages/@vuepress/core/lib/client/root-mixins/updateMeta.js
@@ -23,7 +23,7 @@ export default {
 
     // update title / meta tags
     this.updateMeta()
-    this.updateCanonical()
+    this.updateCanonicalLink()
   },
 
   methods: {
@@ -43,7 +43,7 @@ export default {
         pageMeta, this.siteMeta, metaIdentifier)
     },
 
-    updateCanonical () {
+    updateCanonicalLink () {
       removeCanonicalLink()
 
       if (!this.$canonicalUrl) {
@@ -57,7 +57,7 @@ export default {
   watch: {
     $page () {
       this.updateMeta()
-      this.updateCanonical()
+      this.updateCanonicalLink()
     }
   },
 

--- a/packages/@vuepress/core/lib/client/root-mixins/updateMeta.js
+++ b/packages/@vuepress/core/lib/client/root-mixins/updateMeta.js
@@ -61,6 +61,7 @@ export default {
   watch: {
     $page () {
       this.updateMeta()
+      this.updateCanonical()
     }
   },
 

--- a/packages/@vuepress/core/lib/client/root-mixins/updateMeta.js
+++ b/packages/@vuepress/core/lib/client/root-mixins/updateMeta.js
@@ -13,7 +13,7 @@ export default {
       this.$ssrContext.title = this.$title
       this.$ssrContext.lang = this.$lang
       this.$ssrContext.pageMeta = renderPageMeta(mergedMetaItems)
-      this.$ssrContext.canonical = renderCanonical(this.$canonical)
+      this.$ssrContext.canonicalLink = renderCanonicalLink(this.$canonicalUrl)
     }
   },
   // Other life cycles will only be called at client
@@ -44,17 +44,13 @@ export default {
     },
 
     updateCanonical () {
-      const canonicalEl = document.querySelector("link[rel='canonical']")
+      removeCanonicalLink()
 
-      if (canonicalEl) {
-        canonicalEl.remove()
-      }
-
-      if (!this.$canonical) {
+      if (!this.$canonicalUrl) {
         return
       }
 
-      document.head.insertAdjacentHTML('beforeend', renderCanonical(this.$canonical))
+      document.head.insertAdjacentHTML('beforeend', renderCanonicalLink(this.$canonicalUrl))
     }
   },
 
@@ -67,10 +63,19 @@ export default {
 
   beforeDestroy () {
     updateMetaTags(null, this.currentMetaTags)
+    removeCanonicalLink()
   }
 }
 
-function renderCanonical (link = '') {
+function removeCanonicalLink () {
+  const canonicalEl = document.querySelector("link[rel='canonical']")
+
+  if (canonicalEl) {
+    canonicalEl.remove()
+  }
+}
+
+function renderCanonicalLink (link = '') {
   if (!link) {
     return ''
   }

--- a/packages/@vuepress/core/lib/node/ClientComputedMixin.js
+++ b/packages/@vuepress/core/lib/node/ClientComputedMixin.js
@@ -65,7 +65,7 @@ module.exports = siteData => {
       return this.$localeConfig.title || this.$site.title || ''
     }
 
-    get $canonical () {
+    get $canonicalUrl () {
       const { canonical } = this.$page.frontmatter
 
       if (typeof canonical === 'string') {

--- a/packages/@vuepress/core/lib/node/ClientComputedMixin.js
+++ b/packages/@vuepress/core/lib/node/ClientComputedMixin.js
@@ -65,6 +65,16 @@ module.exports = siteData => {
       return this.$localeConfig.title || this.$site.title || ''
     }
 
+    get $canonical () {
+      const { canonical } = this.$page.frontmatter
+
+      if (typeof canonical === 'string') {
+        return canonical
+      }
+
+      return false
+    }
+
     get $title () {
       const page = this.$page
       const { metaTitle } = this.$page.frontmatter

--- a/packages/docs/docs/guide/frontmatter.md
+++ b/packages/docs/docs/guide/frontmatter.md
@@ -115,7 +115,7 @@ meta:
 - Type: `string`
 - Default: `undefined`
 
-Set the canonical url for the current page.
+Set the canonical URL for the current page.
 
 ## Predefined Variables Powered By Default Theme
 

--- a/packages/docs/docs/guide/frontmatter.md
+++ b/packages/docs/docs/guide/frontmatter.md
@@ -110,6 +110,13 @@ meta:
 ---
 ```
 
+### canonicalUrl <Badge text="1.7.0+" />
+
+- Type: `string`
+- Default: `undefined`
+
+Set the canonical url for the current page.
+
 ## Predefined Variables Powered By Default Theme
 
 ### navbar


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of default theme, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

You have tested in the following browsers: (Providing a detailed version will be better.)

- [x] Chrome
- [x] Firefox
- [x] Safari
- [ ] Edge
- [ ] IE

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature
- [ ] Related documents have been updated
- [ ] Related tests have been updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**

This feature introduces the ability to specify `canonical` in the frontmatter section on a page:

```
---
canonical: https://google.com
---
```

Which will then render the proper head HTML tag, and also keep it updated when the page changes
