### PR TITLE
fix($core): add missing styles for `<OutboundLink />`

### DIFF
--- a/packages/@vuepress/core/lib/client/components/OutboundLink.vue
+++ b/packages/@vuepress/core/lib/client/components/OutboundLink.vue
@@ -43,3 +43,16 @@ export default {
   top: -1px;
 }
 </style>
+
+<style lang="stylus">
+.sr-only
+  position absolute
+  width 1px
+  height 1px
+  padding 0
+  margin -1px
+  overflow hidden
+  clip rect(0, 0, 0, 0)
+  white-space nowrap
+  border-width 0
+</style>

--- a/packages/@vuepress/theme-default/styles/index.styl
+++ b/packages/@vuepress/theme-default/styles/index.styl
@@ -189,17 +189,6 @@ th, td
     .sidebar
       top 0
 
-.sr-only 
-  position absolute
-  width 1px
-  height 1px
-  padding 0
-  margin -1px
-  overflow hidden
-  clip rect(0, 0, 0, 0)
-  white-space nowrap
-  border-width 0
-
 @media (min-width: ($MQMobile + 1px))
   .theme-container.no-sidebar
     .sidebar


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
![image](https://user-images.githubusercontent.com/33315834/95961096-2f085f00-0e37-11eb-9619-1d4971645c20.png)

#2627 adds a hint with `sr-only` class, but the class style is placed in `@vue/theme-default` by mistake.

OutboundLink is an internal component, and will effect all the themes, so the style must be placed in the component.