### PR TITLE
feat($markdown): make page suffix configurable (close #2452)

### DIFF
--- a/packages/@vuepress/markdown/__tests__/link.spec.js
+++ b/packages/@vuepress/markdown/__tests__/link.spec.js
@@ -2,13 +2,19 @@ import { Md } from './util'
 import link from '../lib/link.js'
 import { dataReturnable } from '../index.js'
 
-const externalAttrs = {
+const EXTERNAL_ATTRS = {
   target: '_blank',
   rel: 'noopener noreferrer'
 }
-const mdL = Md().use(link, externalAttrs)
 
-dataReturnable(mdL)
+const setup = ({ externalAttrs = EXTERNAL_ATTRS, suffix } = {}) => {
+  const mdL = Md().use(link, EXTERNAL_ATTRS, suffix)
+  dataReturnable(mdL)
+
+  return mdL
+}
+
+const mdL = setup()
 
 const internalLinkAsserts = {
   // START absolute path usage
@@ -73,9 +79,8 @@ describe('link', () => {
 
   test('with custom page suffix should render links correctly', () => {
     const suffix = '/'
-    const mdLSuffix = Md().use(link, externalAttrs, suffix)
+    const mdLSuffix = setup({ suffix })
 
-    dataReturnable(mdLSuffix)
     for (const before in internalLinkAsserts) {
       const input = `[${before}](${before})`
       const output = mdLSuffix.render(input)

--- a/packages/@vuepress/markdown/__tests__/link.spec.js
+++ b/packages/@vuepress/markdown/__tests__/link.spec.js
@@ -2,10 +2,11 @@ import { Md } from './util'
 import link from '../lib/link.js'
 import { dataReturnable } from '../index.js'
 
-const mdL = Md().use(link, {
+const externalAttrs = {
   target: '_blank',
   rel: 'noopener noreferrer'
-})
+}
+const mdL = Md().use(link, externalAttrs)
 
 dataReturnable(mdL)
 
@@ -67,6 +68,22 @@ describe('link', () => {
     for (const link of externalLinks) {
       const { html } = mdL.render(link)
       expect(html).toMatchSnapshot()
+    }
+  })
+
+  test('with custom page suffix should render links correctly', () => {
+    const suffix = '/'
+    const mdLSuffix = Md().use(link, externalAttrs, suffix)
+
+    dataReturnable(mdLSuffix)
+    for (const before in internalLinkAsserts) {
+      const input = `[${before}](${before})`
+      const output = mdLSuffix.render(input)
+      const after = getCompiledLink(output)
+      const value = internalLinkAsserts[before]
+      const isHtmlLink = value === before
+      const expected = isHtmlLink ? value : value.replace('.html', suffix)
+      expect(after).toBe(expected)
     }
   })
 })

--- a/packages/@vuepress/markdown/index.js
+++ b/packages/@vuepress/markdown/index.js
@@ -31,6 +31,7 @@ const {
 module.exports = (markdown = {}) => {
   const {
     externalLinks,
+    pageSuffix,
     anchor,
     toc,
     plugins,
@@ -73,7 +74,7 @@ module.exports = (markdown = {}) => {
       .use(convertRouterLinkPlugin, [Object.assign({
         target: '_blank',
         rel: 'noopener noreferrer'
-      }, externalLinks)])
+      }, externalLinks), pageSuffix])
       .end()
 
     .plugin(PLUGINS.HOIST_SCRIPT_STYLE)

--- a/packages/@vuepress/markdown/lib/link.js
+++ b/packages/@vuepress/markdown/lib/link.js
@@ -6,7 +6,7 @@ const url = require('url')
 
 const indexRE = /(^|.*\/)(index|readme).md(#?.*)$/i
 
-module.exports = (md, externalAttrs) => {
+module.exports = (md, externalAttrs, pageSuffix = '.html') => {
   let hasOpenRouterLink = false
   let hasOpenExternalLink = false
 
@@ -28,13 +28,13 @@ module.exports = (md, externalAttrs) => {
         }
       } else if (isSourceLink) {
         hasOpenRouterLink = true
-        tokens[idx] = toRouterLink(token, link, relativePath)
+        tokens[idx] = toRouterLink(token, link, relativePath, pageSuffix)
       }
     }
     return self.renderToken(tokens, idx, options)
   }
 
-  function toRouterLink (token, link, relativePath) {
+  function toRouterLink (token, link, relativePath, suffix) {
     link[0] = 'to'
     let to = link[1]
 
@@ -55,8 +55,8 @@ module.exports = (md, externalAttrs) => {
       to = path + hash
     } else {
       to = to
-        .replace(/\.md$/, '.html')
-        .replace(/\.md(#.*)$/, '.html$1')
+        .replace(/\.md$/, suffix)
+        .replace(/\.md(#.*)$/, `${suffix}$1`)
     }
 
     // markdown-it encodes the uri

--- a/packages/docs/docs/config/README.md
+++ b/packages/docs/docs/config/README.md
@@ -277,6 +277,13 @@ Function for transforming [header](../miscellaneous/glossary.md#headers) texts i
 
 Options for [markdown-it-anchor](https://github.com/valeriangalliat/markdown-it-anchor). (Note: prefer `markdown.slugify` to customize header ids.)
 
+### markdown.pageSuffix
+
+- Type: `string`
+- Default: `.html`
+
+Option to customize internal links to be compatible when using the [vuepress-plugin-clean-urls](https://vuepress.github.io/en/plugins/clean-urls/).
+
 ### markdown.externalLinks
 
 - Type: `Object`

--- a/packages/docs/docs/guide/markdown.md
+++ b/packages/docs/docs/guide/markdown.md
@@ -43,6 +43,12 @@ VuePress supports redirecting to clean links. If a link `/foo` is not found, Vue
 Regardless of whether the permalink and clean-urls plugins are used, your relative path should be defined by the current file structure. In the above example, even though you set the path of `/foo/one.md` to `/foo/one/`, you should still access `/foo/two.md` via `./two.md`.
 :::
 
+### Page Suffix
+
+Pages and internal links get generated with the `.html` suffix by default.
+
+You can customize this by setting [config.markdown.pageSuffix](../config/README.md#markdown-pagesuffix).
+
 ### External Links
 
 Outbound links automatically get `target="_blank" rel="noopener noreferrer"`:

--- a/packages/docs/docs/zh/config/README.md
+++ b/packages/docs/docs/zh/config/README.md
@@ -273,6 +273,13 @@ VuePress 提供了一种添加额外样式的简便方法。你可以创建一�
 
 [markdown-it-anchor](https://github.com/valeriangalliat/markdown-it-anchor) 的选项。
 
+### markdown.pageSuffix
+
+- 类型: `string`
+- 默认值: `.html`
+
+Option to customize internal links to be compatible when using the [vuepress-plugin-clean-urls](https://vuepress.github.io/en/plugins/clean-urls/).
+
 ### markdown.externalLinks
 
 - 类型: `Object`

--- a/packages/docs/docs/zh/guide/markdown.md
+++ b/packages/docs/docs/zh/guide/markdown.md
@@ -43,6 +43,12 @@ VuePress 支持重定向到干净链接。如果一个链接 `/foo` 找不到，
 无论是否使用了 permalink 和 clean-urls 插件，你的相对路径都应该依赖于当前的文件结构来定义。在上面的例子中，即使你将 `/foo/one.md` 的路径设为了 `/foo/one/`，你依然应该通过 `./two.md` 来访问 `/foo/two.md`。
 :::
 
+### Page Suffix
+
+Pages and internal links get generated with the `.html` suffix by default.
+
+You can customize this by setting [config.markdown.pageSuffix](../config/README.md#markdown-pagesuffix).
+
 ### 外部链接
 
 外部的链接将会被自动地设置为  `target="_blank" rel="noopener noreferrer"`:


### PR DESCRIPTION
**Summary**

Extends the markdown link plugin with an option for the page suffix, which is currently hardcoded to `.html`.

This fixes broken links in the markup (and hence non-js version) when using the clean urls plugin. See #2452 for details.

Fixes #2452.

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:z

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

You have tested in the following browsers: (Providing a detailed version will be better.)

- [x] Chrome
- [x] Firefox
- [x] Safari
- [ ] Edge
- [ ] IE

If adding a **new feature**, the PR's description includes:

- [x] A convincing reason for adding this feature
- [x] Related documents have been updated
- [x] Related tests have been updated

**Other information:**

See the [associated feature request issue](https://github.com/vuejs/vuepress/issues/2452) for detailed description and previous discussion.
