### PR TITLE
fix($markdown): support path without file extension when importing code snippets

### DIFF
--- a/packages/@vuepress/markdown/__tests__/__snapshots__/snippet.spec.js.snap
+++ b/packages/@vuepress/markdown/__tests__/__snapshots__/snippet.spec.js.snap
@@ -1,9 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`snippet import snippet 1`] = `
-<pre><code class="language-js">export default function () {
-  // ..
-}
+<pre><code># Sample snippet file with no filename extension.
+FROM ubuntu:latest
+CMD echo hello!
 </code></pre>
 `;
 

--- a/packages/@vuepress/markdown/__tests__/__snapshots__/snippet.spec.js.snap
+++ b/packages/@vuepress/markdown/__tests__/__snapshots__/snippet.spec.js.snap
@@ -1,6 +1,10 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`snippet import snippet 1`] = `
+<pre><code class="language-js">export default function () {
+  // ..
+}
+</code></pre>
 <pre><code># Sample snippet file with no filename extension.
 FROM ubuntu:latest
 CMD echo hello!

--- a/packages/@vuepress/markdown/__tests__/fragments/Dockerfile
+++ b/packages/@vuepress/markdown/__tests__/fragments/Dockerfile
@@ -1,0 +1,3 @@
+# Sample snippet file with no filename extension.
+FROM ubuntu:latest
+CMD echo hello!

--- a/packages/@vuepress/markdown/__tests__/fragments/code-snippet.md
+++ b/packages/@vuepress/markdown/__tests__/fragments/code-snippet.md
@@ -1,1 +1,1 @@
-<<< @/packages/@vuepress/markdown/__tests__/fragments/snippet.js
+<<< @/packages/@vuepress/markdown/__tests__/fragments/Dockerfile

--- a/packages/@vuepress/markdown/__tests__/fragments/code-snippet.md
+++ b/packages/@vuepress/markdown/__tests__/fragments/code-snippet.md
@@ -1,1 +1,3 @@
+<<< @/packages/@vuepress/markdown/__tests__/fragments/snippet.js
+
 <<< @/packages/@vuepress/markdown/__tests__/fragments/Dockerfile

--- a/packages/@vuepress/markdown/lib/snippet.js
+++ b/packages/@vuepress/markdown/lib/snippet.js
@@ -137,7 +137,7 @@ module.exports = function snippet (md, options = {}) {
      *
      * captures: ['/path/to/file.extension', 'extension', '#region', '{meta}']
      */
-    const rawPathRegexp = /^(.+(?:\.([a-z]+)))(?:(#[\w-]+))?(?: ?({\d+(?:[,-]\d+)*}))?$/
+    const rawPathRegexp = /^(.+?(?:\.([a-z]+))?)(?:(#[\w-]+))?(?: ?({\d+(?:[,-]\d+)*}))?$/
 
     const rawPath = state.src.slice(start, end).trim().replace(/^@/, root).trim()
     const [filename = '', extension = '', region = '', meta = ''] = (rawPathRegexp.exec(rawPath) || []).slice(1)


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

This PR fixes an issue where [code snippets in markdown](https://v1.vuepress.vuejs.org/guide/markdown.html#import-code-snippets) can reference a filename to include _only if_ the filename has an extension.

For example, including a snippet like this:
```
<<< @/path/to/Dockerfile
```
(note the path does not contain a `.`) results in the snippet being rendered as the string `Invalid code snippet option` even if the target file exists.

The bug is caused by an overly restrictive regex that demands at least one literal `.` in the include path. This PR fixes the regex and adds a test case.

My personal preference would be to refactor the relatively large regex into simpler parsing steps, but I don't want to mess with it and inadvertently introduce subtle side effects :/

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of default theme, please provide the **before/after** screenshot: N/A

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications: N/A

**The PR fulfills these requirements:**

- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

You have tested in the following browsers: (Providing a detailed version will be better.)

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
- [ ] IE

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature
- [ ] Related documents have been updated
- [ ] Related tests have been updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
