### PR TITLE
fix($theme-default): display header-anchor links when using keyboard navigation

### DIFF
--- a/packages/@vuepress/theme-default/styles/index.styl
+++ b/packages/@vuepress/theme-default/styles/index.styl
@@ -125,6 +125,7 @@ h1, h2, h3, h4, h5, h6
       + p, + pre, + .custom-block
         margin-top 2rem
 
+  &:focus .header-anchor,
   &:hover .header-anchor
     opacity: 1
 
@@ -147,6 +148,7 @@ a.header-anchor
   margin-top 0.125em
   opacity 0
 
+  &:focus,
   &:hover
     text-decoration none
 


### PR DESCRIPTION
**Summary**

a11y: When using keyboard navigation the header-anchor link (the **#** tag before the heading) is not visible, this PR fixies this bug.

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [x] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

You have tested in the following browsers: (Providing a detailed version will be better.)

- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge
- [ ] IE

**Other information:**

To recreate the issue, try navigating using you keyboard (with the `TAB` key) in a page with many `h1`-`h6` headings. You won't see the heading-anchor link (the **#** tag before the heading). But when you hover with your mouse over a heading you will see the heading-anchor link.

Why? because the code uses only `:hover` (for mouse users). It should also include `:focus` (for keyboard users).