### PR TITLE
feat: Add description to meta title when no selfTitle

### DIFF
--- a/packages/@vuepress/core/lib/node/ClientComputedMixin.js
+++ b/packages/@vuepress/core/lib/node/ClientComputedMixin.js
@@ -87,10 +87,12 @@ module.exports = siteData => {
         page.frontmatter.title // explicit title
         || page.title // inferred title
       )
+      const description = this.$description.trim()
+      const siteTitleAndDescription = description.length > 0 ? siteTitle + ' | ' + description : siteTitle
       return siteTitle
         ? selfTitle
           ? (selfTitle + ' | ' + siteTitle)
-          : siteTitle
+          : siteTitleAndDescription
         : selfTitle || 'VuePress'
     }
 


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**
Matches the behavior of other SSGs such as Jekyll to facilitate migration. Mainly impacts home page. Allows search engines to display more meaningful information than just a name in search result title.

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of default theme, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [ ] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

You have tested in the following browsers: (Providing a detailed version will be better.)

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
- [ ] IE

If adding a **new feature**, the PR's description includes:

- [x] A convincing reason for adding this feature
- [ ] Related documents have been updated
- [ ] Related tests have been updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
