### PR TITLE
feat/support https in vuepress log output (fix #2357 #2358)

### DIFF
--- a/packages/@vuepress/core/lib/node/dev/index.js
+++ b/packages/@vuepress/core/lib/node/dev/index.js
@@ -175,7 +175,8 @@ module.exports = class DevProcess extends EventEmitter {
         port: this.port,
         displayHost: this.displayHost,
         publicPath: this.context.base,
-        clearScreen: !(this.context.options.debug || !this.context.options.clearScreen)
+        clearScreen: !(this.context.options.debug || !this.context.options.clearScreen),
+        isHttps: (this.context.siteConfig.devServer || {}).https
       }])
 
     config = config.toConfig()

--- a/packages/@vuepress/core/lib/node/webpack/DevLogPlugin.js
+++ b/packages/@vuepress/core/lib/node/webpack/DevLogPlugin.js
@@ -17,7 +17,7 @@ module.exports = class DevLogPlugin {
 
   apply (compiler) {
     let isFirst = true
-    const { displayHost, port, publicPath, clearScreen: shouldClearScreen } = this.options
+    const { displayHost, port, publicPath, clearScreen: shouldClearScreen, isHttps } = this.options
 
     compiler.hooks.done.tap('vuepress-log', stats => {
       if (shouldClearScreen) {
@@ -25,7 +25,7 @@ module.exports = class DevLogPlugin {
       }
 
       const time = new Date().toTimeString().match(/^[\d:]+/)[0]
-      const displayUrl = `http://${displayHost}:${port}${publicPath}`
+      const displayUrl = `http${isHttps ? 's' : ''}://${displayHost}:${port}${publicPath}`
 
       logger.success(
         `${chalk.gray(`[${time}]`)} Build ${chalk.italic(stats.hash.slice(0, 6))} `


### PR DESCRIPTION
**Summary**

Make the URL displayed in output logged by the dev server accurately reflects whether the dev server is running in HTTPS mode or not.

> NOTE: I'm aware this repo is at or near EOL. This is such a minor tweak, at the very least I thought someone else might find it useful and/or something similar might find its way into v2 or Vitepress. Won't be upset/offended/discouraged if it gets closed/rejected without merge.

**Explanation/Justification**

This is mostly a cosmetic/convenience change. Previously, when running the dev server (`yarn docs:dev` or `npm run docs:dev`), the console would output messages like:

* `VuePress dev server listening at http://docs.example.test:8080/`
* `success [16:27:43] Build b6b75d finished in 111 ms! ( http://docs.example.test:8080/ )`

Many editors (e.g. VSCode) allow the developer to hover over that URL and open up the link in a web browser. The problem was that the `http://` part of the URLs displayed here were hard-coded. Since it is relatively easy to run the local dev server using SSL, and this is desirable for making the dev environment match the deployment environment as closely as possible, it would be nice if the URLs logged to the console accurately reflected this. Running locally in SSL mode is also a good way to be able to test the PWA functions of your Vuepress site before deployment (although I haven't tested this).

To set up SSL for the local dev server:

1. [Update your `hosts` file](https://www.howtogeek.com/howto/27350/beginner-geek-how-to-edit-your-hosts-file/) to add a custom domain at which to test, e.g. `docs.example.test`. [Using a `*.test` TLD is recommended](https://en.wikipedia.org/wiki/.test) for local testing (and may be required to get this to work in some browsers?).
2. Install locally-trusted SSL certificates. [`mkcert` is a nice tool for this](https://github.com/FiloSottile/mkcert). By running `mkcert docs.example.test` in the root of the Vuepress project, the cert and key pem files will be generated and registered to be trusted by your local machine.
3. Update your `.vuepress/config.js` accordingly (NOTE: update the path to the certs according to your project structure):
    ```js
    const fs = require('fs')
    const path = require('path')
    module.exports = {
      title: 'My Docs',
      description: 'Everything you need to know to use my app',
      host: 'docs.example.test',
      devServer: {
        https: true,
        key: fs.readFileSync(path.resolve(__dirname, '..', '..', 'docs.example.test-key.pem'), 'utf8'),
        cert: fs.readFileSync(path.resolve(__dirname, '..', '..', 'docs.example.test.pem'), 'utf8'),
      },
    }
    ```
With this PR, once you've added SSL to your dev server in this way, the URL logged to the console will look something like `https://docs.example.test:8080`.

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of default theme, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

You have tested in the following browsers: (Providing a detailed version will be better.)

- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
- [ ] IE

If adding a **new feature**, the PR's description includes:

- [x] A convincing reason for adding this feature
- [ ] Related documents have been updated
- [x] Related tests have been updated

No unit tests were added, but I did run the tests after making the change to make sure it didn't break anything.

**Other information:**

#2357 and #2358 would be addressed by this.