### PR TITLE
Fix #2836 Show at least 60 characters of code at all times

### DIFF
--- a/packages/@vuepress/core/lib/client/style/config.styl
+++ b/packages/@vuepress/core/lib/client/style/config.styl
@@ -17,8 +17,8 @@ $contentWidth ?= 740px
 $homePageWidth ?= 960px
 
 // responsive breakpoints
-$MQNarrow ?= 959px
-$MQMobile ?= 719px
+$MQNarrow ?= 1065px
+$MQMobile ?= 865px
 $MQMobileNarrow ?= 419px
 
 // code


### PR DESCRIPTION
**Summary**
The layout starts getting cramped to less than 80 characters of code at 1080p width (1065dppx minus scrollbar).
It becomes near unusable below 60 characters, which translates to 865px with sidebar open and scrollbars.

**What kind of change does this PR introduce?**

- [x] Bugfix

Before:
![Screenshot from 2021-04-30 14-36-19](https://user-images.githubusercontent.com/876076/116745959-77e1c880-a9c1-11eb-9ec8-97f49959fd9f.png)

After:
![Screenshot from 2021-04-30 14-33-56](https://user-images.githubusercontent.com/876076/116745853-5385ec00-a9c1-11eb-9e36-7d84303b9162.png)
![Screenshot from 2021-04-30 14-29-07](https://user-images.githubusercontent.com/876076/116745855-541e8280-a9c1-11eb-9dfd-ef5da134e344.png)

**Does this PR introduce a breaking change?**

- [x] No

You have tested in the following browsers: (Providing a detailed version will be better.)

- [x] Chrome
- [x] Firefox
- [x] Safari
- [x] Edge
- [x] IE
