### PR TITLE
feat($plugin-search): prevent iOS input zoom on focus

### DIFF
--- a/packages/@vuepress/plugin-search/SearchBox.vue
+++ b/packages/@vuepress/plugin-search/SearchBox.vue
@@ -210,7 +210,8 @@ export default {
     display inline-block
     border 1px solid darken($borderColor, 10%)
     border-radius 2rem
-    font-size 0.9rem
+    // Prevent iOS input zoom on focus
+    font-size max(min(16px, 100%), 1rem)
     line-height 2rem
     padding 0 0.5rem 0 2rem
     outline none


### PR DESCRIPTION
Apple decided that form inputs on iOS need to be a comfortable reading size, set at a minimum of 16px. If the form input font-size is less than that, they will automatically zoom into the field until the text appears at that size.

To prevent this behaviour this commit sets the `font-size` to `16px`.

| Before       | After    | 
| :------------- | :----------: | 
| ![IMG_5095](https://user-images.githubusercontent.com/464300/116899955-7cfc7d00-ac38-11eb-98c4-416acdd9b93a.png) | ![IMG_5094](https://user-images.githubusercontent.com/464300/116899940-7a018c80-ac38-11eb-9888-21d76b76bb83.png) | 


<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of default theme, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

You have tested in the following browsers: (Providing a detailed version will be better.)

- [x] Chrome
- [x] Firefox
- [x] Safari
- [x] Edge
- [ ] IE

If adding a **new feature**, the PR's description includes:

- [x] A convincing reason for adding this feature
- [ ] Related documents have been updated
- [ ] Related tests have been updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**

https://twitter.com/andreruffert/status/1380287868581609472
