### PR TITLE
feat($plugin-last-updated): add "$page.lastUpdatedTimestamp"

### DIFF
--- a/packages/@vuepress/plugin-last-updated/index.js
+++ b/packages/@vuepress/plugin-last-updated/index.js
@@ -11,6 +11,7 @@ module.exports = (options = {}, context) => ({
         ? transformer(timestamp, $lang)
         : defaultTransformer(timestamp, $lang, dateOptions)
       $page.lastUpdated = lastUpdated
+      $page.lastUpdatedTimestamp = timestamp
     }
   }
 })


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

Some plugins depends of `$page.lastUpdated` to get the last updated date of a document, example https://github.com/lorisleiva/vuepress-plugin-seo or https://github.com/ekoeryanto/vuepress-plugin-sitemap. 

However, due to the changes on the default transformer which adds support for localized date, passing a lang in the frontmatter header (ex: `lang: fr`) returns a string formatted like this `04/05/2021 à 23:29:04` which can't be parsed through `new Date()`, see https://github.com/lorisleiva/vuepress-plugin-seo/issues/9 or https://github.com/ekoeryanto/vuepress-plugin-sitemap/blob/master/index.js#L24.

I don't think it's a nice idea to pass a custom transformer which just return the timestamp, because it means people will have to use theme inheritance **just** for re-formatting a localized date.

Instead, adding a new key `lastUpdatedTimestamp` which now contains the raw timestamp value without any transformation on it, in order to be easily used by other plugins.

WDYT?

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of default theme, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

You have tested in the following browsers: (Providing a detailed version will be better.)

- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
- [ ] IE

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature
- [ ] Related documents have been updated
- [ ] Related tests have been updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
