### PR TITLE
fix($plugin-search): ignore Enter key when converting text (fix #2850)

### DIFF
--- a/packages/@vuepress/plugin-search/SearchBox.vue
+++ b/packages/@vuepress/plugin-search/SearchBox.vue
@@ -1,20 +1,21 @@
 <template>
   <div class="search-box">
-    <input
-      ref="input"
-      aria-label="Search"
-      :value="query"
-      :class="{ 'focused': focused }"
-      :placeholder="placeholder"
-      autocomplete="off"
-      spellcheck="false"
-      @input="query = $event.target.value"
-      @focus="focused = true"
-      @blur="focused = false"
-      @keyup.enter="go(focusIndex)"
-      @keyup.up="onUp"
-      @keyup.down="onDown"
-    >
+    <form @submit.prevent="go(focusIndex)">
+      <input
+        ref="input"
+        aria-label="Search"
+        :value="query"
+        :class="{ 'focused': focused }"
+        :placeholder="placeholder"
+        autocomplete="off"
+        spellcheck="false"
+        @input="query = $event.target.value"
+        @focus="focused = true"
+        @blur="focused = false"
+        @keyup.up="onUp"
+        @keyup.down="onDown"
+      >
+    </form>
     <ul
       v-if="showSuggestions"
       class="suggestions"


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

Fix #2850 

Ignore Enter key input when converting text using `<form>` tag ([Implicit submission of Form](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#implicit-submission)). 

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of default theme, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

You have tested in the following browsers: (Providing a detailed version will be better.)

- [x] Chrome
- [x] Firefox
- [x] Safari
- [ ] Edge
- [ ] IE

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature
- [ ] Related documents have been updated
- [ ] Related tests have been updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
