### PR TITLE
doc fix: plugin-pwa config error

### DIFF
--- a/packages/docs/docs/zh/plugin/official/plugin-pwa.md
+++ b/packages/docs/docs/zh/plugin/official/plugin-pwa.md
@@ -18,7 +18,7 @@ yarn add -D @vuepress/plugin-pwa
 
 ```javascript
 module.exports = {
-  plugins: ['@vuepress/pwa']
+  plugins: ['@vuepress/plugin-pwa']
 }
 ```
 


### PR DESCRIPTION
the name of pwa plugin need to be "@vuepress/plugin-pwa", not “@vuepress/pwa". Or the plugin pwa will be ignored during building process.

<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [x] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of default theme, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

You have tested in the following browsers: (Providing a detailed version will be better.)

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
- [ ] IE

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature
- [ ] Related documents have been updated
- [ ] Related tests have been updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
