### PR TITLE
feat($theme-default): `CodeGroup` supports changing tab automatically

### DIFF
--- a/packages/@vuepress/theme-default/global-components/CodeGroup.vue
+++ b/packages/@vuepress/theme-default/global-components/CodeGroup.vue
@@ -45,10 +45,16 @@ export default {
   },
   mounted () {
     this.loadTabs()
+    this.$root.$on('changeAllCodeTab', (index) => {
+      if (this.activeCodeTabIndex !== index) {
+        this.changeCodeTab(index)
+      }
+    })
   },
   methods: {
     changeCodeTab (index) {
       this.activeCodeTabIndex = index
+      this.$root.$emit('changeAllCodeTab', index)
     },
     loadTabs () {
       this.codeTabs = (this.$slots.default || []).filter(slot => Boolean(slot.componentOptions)).map((slot, index) => {


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of default theme, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

You have tested in the following browsers: (Providing a detailed version will be better.)

- [x] Chrome
- [ ] Firefox
- [x] Safari
- [ ] Edge
- [ ] IE

If adding a **new feature**, the PR's description includes:

- [x] A convincing reason for adding this feature
- [ ] Related documents have been updated
- [ ] Related tests have been updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
This feature will change the behavior of `CodeGroup`, when one `CodeGroup` changes its tab, other `CodeGroup`s in the whole page will change theirs tabs automatically.

