### PR TITLE
feat(theme-default): set home footer with markdown slot (close: #2993)

### DIFF
--- a/packages/@vuepress/theme-default/components/Home.vue
+++ b/packages/@vuepress/theme-default/components/Home.vue
@@ -57,6 +57,12 @@
     >
       {{ data.footer }}
     </div>
+
+    <Content
+      v-else
+      slot-key="footer"
+      class="footer"
+    />
   </main>
 </template>
 

--- a/packages/docs/docs/index.md
+++ b/packages/docs/docs/index.md
@@ -3,7 +3,6 @@ home: true
 heroImage: /hero.png
 actionText: Get Started →
 actionLink: /guide/getting-started.html
-footer: MIT Licensed | Copyright © 2018-present Evan You
 ---
 
 <div class="features">
@@ -20,3 +19,7 @@ footer: MIT Licensed | Copyright © 2018-present Evan You
     <p>VuePress generates pre-rendered static HTML for each page, and runs as an SPA once a page is loaded.</p>
   </div>
 </div>
+
+::: slot footer
+MIT Licensed | Copyright © 2018-present [Evan You](https://github.com/yyx990803)
+:::

--- a/packages/docs/docs/theme/default-theme-config.md
+++ b/packages/docs/docs/theme/default-theme-config.md
@@ -35,6 +35,20 @@ Any extra content after the `YAML front matter` will be parsed as normal Markdow
 
 To use a fully custom homepage layout, you can also use a [Custom Layout](#custom-layout-for-specific-pages).
 
+## Rich-text footer
+
+Note that you can also set `footer` with [Markdown Slot Syntax](../guide/markdown-slot.md) to support rich text:
+
+```md
+---
+home: true
+---
+
+::: slot footer
+MIT Licensed | Copyright © 2018-present [Evan You](https://github.com/yyx990803)
+:::
+```
+
 ## Navbar
 
 The Navbar may contain your page title, [Search Box](#search-box), [Navbar Links](#navbar-links), [Languages](../guide/i18n.md) and [Repository Link](#git-repo-and-edit-links), they all depend on your configuration.

--- a/packages/docs/docs/zh/theme/default-theme-config.md
+++ b/packages/docs/docs/zh/theme/default-theme-config.md
@@ -31,6 +31,20 @@ footer: MIT Licensed | Copyright © 2018-present Evan You
 
 任何 `YAML front matter` 之后额外的内容将会以普通的 markdown 被渲染，并插入到 `features` 的后面。
 
+## 富文本 footer
+
+你还可以使用 [Markdown Slot Syntax](../guide/markdown-slot.md) 来设置 `footer`，以支持富文本：
+
+```md
+---
+home: true
+---
+
+::: slot footer
+MIT Licensed | Copyright © 2018-present [Evan You](https://github.com/yyx990803)
+:::
+```
+
 ## 导航栏
 
 导航栏可能包含你的页面标题、[搜索框](#搜索框)、 [导航栏链接](#导航栏链接)、[多语言切换](../guide/i18n.md)、[仓库链接](#git-仓库和编辑链接)，它们均取决于你的配置。


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

Set `footer` with [Markdown Slot Syntax](../guide/markdown-slot.md) to support rich text:

```md
---
home: true
---

::: slot footer
MIT Licensed | Copyright © 2018-present [Evan You](https://github.com/yyx990803)
:::
```

close: #2993

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of default theme, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

You have tested in the following browsers: (Providing a detailed version will be better.)

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
- [ ] IE

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature
- [ ] Related documents have been updated
- [ ] Related tests have been updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
