### PR TITLE
feat(theme-default): headings anchor should not be selectable

### DIFF
--- a/packages/@vuepress/theme-default/styles/index.styl
+++ b/packages/@vuepress/theme-default/styles/index.styl
@@ -146,6 +146,7 @@ a.header-anchor
   margin-left -0.87em
   padding-right 0.23em
   margin-top 0.125em
+  user-select none
   opacity 0
 
   &:focus,


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

Currently, when users select the page content to copy & paste the text, it also selects the headings **#** anchors. This PR removes the headings anchor-selection by defining the anchors as not selectable (`user-select: none;`).

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of default theme, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

You have tested in the following browsers: (Providing a detailed version will be better.)

- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
- [ ] IE

If adding a **new feature**, the PR's description includes:

- [x] A convincing reason for adding this feature
- [ ] Related documents have been updated
- [ ] Related tests have been updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**

I created a similar PR in vuepress-next, see https://github.com/vuepress/vuepress-next/pull/973